### PR TITLE
Refactor constraint generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
 name = "liquid-rust-common"
 version = "0.1.0"
 dependencies = [
- "indexmap",
+ "rustc-workspace-hack",
 ]
 
 [[package]]
@@ -320,7 +320,9 @@ name = "liquid-rust-typeck"
 version = "0.1.0"
 dependencies = [
  "liquid-rust-common",
+ "liquid-rust-fixpoint",
  "liquid-rust-lrir",
+ "rustc-workspace-hack",
 ]
 
 [[package]]

--- a/liquid-rust-common/src/ordered_map.rs
+++ b/liquid-rust-common/src/ordered_map.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 /// An associative array that preserves insertion order.
 #[derive(Default)]
 pub struct OrderedMap<K, V> {
-    inner: Vec<(K, V)>,
+    pub inner: Vec<(K, V)>,
 }
 
 impl<K, V> OrderedMap<K, V> {

--- a/liquid-rust-common/src/ordered_map.rs
+++ b/liquid-rust-common/src/ordered_map.rs
@@ -3,7 +3,7 @@ use std::iter::FromIterator;
 /// An associative array that preserves insertion order.
 #[derive(Default)]
 pub struct OrderedMap<K, V> {
-    pub inner: Vec<(K, V)>,
+    inner: Vec<(K, V)>,
 }
 
 impl<K, V> OrderedMap<K, V> {

--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -11,6 +11,7 @@ use std::fmt;
 pub enum Constraint {
     Pred(Pred),
     Conj(Vec<Self>),
+    Guard(Pred, Box<Self>),
     ForAll(Sort, Pred, Box<Self>),
 }
 
@@ -53,6 +54,9 @@ impl Emit for Constraint {
                         conclusion
                     )
                 }
+            }
+            Self::Guard(premise, conclusion) => {
+                emit!(w, ctx, "(forall ((_ int) ({})) {})", premise, conclusion)
             }
         }
     }

--- a/liquid-rust-fixpoint/src/embed/mod.rs
+++ b/liquid-rust-fixpoint/src/embed/mod.rs
@@ -1,4 +1,4 @@
-use crate::Fixpoint;
+use crate::{pred::Expr, Fixpoint};
 
 pub trait Embed {
     type Output;
@@ -37,21 +37,21 @@ impl Embed for ty::Constant {
 use crate::pred::Pred;
 
 impl Embed for ty::Pred {
-    type Output = Pred;
+    type Output = Expr;
 
     fn embed(&self, fixpoint: &Fixpoint) -> Self::Output {
         match self.kind() {
             ty::PredKind::Path(path) => {
                 assert_eq!(0, path.projection.len());
-                Pred::Variable(fixpoint.get_index(&path.var).unwrap())
+                Expr::Variable(fixpoint.get_index(&path.var).unwrap())
             }
-            ty::PredKind::BinaryOp(bin_op, lop, rop) => Pred::BinaryOp(
+            ty::PredKind::BinaryOp(bin_op, lop, rop) => Expr::BinaryOp(
                 *bin_op,
                 Box::new(lop.embed(fixpoint)),
                 Box::new(rop.embed(fixpoint)),
             ),
-            ty::PredKind::UnaryOp(un_op, op) => Pred::UnaryOp(*un_op, Box::new(op.embed(fixpoint))),
-            ty::PredKind::Const(constant) => Pred::Constant(constant.embed(fixpoint)),
+            ty::PredKind::UnaryOp(un_op, op) => Expr::UnaryOp(*un_op, Box::new(op.embed(fixpoint))),
+            ty::PredKind::Const(constant) => Expr::Constant(constant.embed(fixpoint)),
         }
     }
 }
@@ -61,14 +61,14 @@ impl Embed for ty::Refine {
 
     fn embed(&self, fixpoint: &Fixpoint) -> Self::Output {
         match self {
-            ty::Refine::Infer(kvar) => Pred::Kvar(
+            ty::Refine::Infer(kvar) => Pred::KVar(
                 kvar.id,
                 kvar.vars
                     .iter()
                     .filter_map(|var| fixpoint.get_index(var))
                     .collect(),
             ),
-            ty::Refine::Pred(pred) => pred.embed(fixpoint),
+            ty::Refine::Pred(pred) => Pred::Expr(pred.embed(fixpoint)),
         }
     }
 }

--- a/liquid-rust-typeck/src/binding_tree.rs
+++ b/liquid-rust-typeck/src/binding_tree.rs
@@ -17,7 +17,7 @@ newtype_index! {
 pub struct BindingTree {
     nodes: IndexVec<NodeId, Node>,
     curr_path: Vec<NodeId>,
-    pub curr_bindings: OrderedMap<Var, Ty>,
+    curr_bindings: OrderedMap<Var, Ty>,
 }
 
 impl BindingTree {

--- a/liquid-rust-typeck/src/binding_tree.rs
+++ b/liquid-rust-typeck/src/binding_tree.rs
@@ -17,16 +17,13 @@ newtype_index! {
 pub struct BindingTree {
     nodes: IndexVec<NodeId, Node>,
     curr_path: Vec<NodeId>,
-    curr_bindings: OrderedMap<Var, Ty>,
+    pub curr_bindings: OrderedMap<Var, Ty>,
 }
 
 impl BindingTree {
     pub fn new() -> Self {
         let mut nodes = IndexVec::new();
-        let curr_node = nodes.push(Node {
-            kind: NodeKind::Blank,
-            children: vec![],
-        });
+        let curr_node = nodes.push(Node::Blank(vec![]));
         Self {
             nodes,
             curr_path: vec![curr_node],
@@ -45,7 +42,8 @@ impl BindingTree {
             .skip(depth)
             .filter(|node_id| self.nodes[**node_id].is_binding())
             .count();
-        self.curr_bindings.truncate(bindings_count);
+        self.curr_bindings
+            .truncate(self.curr_bindings.len() - bindings_count);
         self.curr_path.truncate(depth);
     }
 
@@ -56,30 +54,22 @@ impl BindingTree {
 
     pub fn push_binding<V: Into<Var>>(&mut self, var: V, ty: Ty) {
         let var = var.into();
-        self.push_node(Node {
-            kind: NodeKind::Binding(var, ty.clone()),
-            children: vec![],
-        });
+        self.push_node(Node::Binding(var, ty.clone(), vec![]));
         self.curr_bindings.insert(var, ty);
     }
 
     pub fn push_guard(&mut self, refine: Refine) {
-        self.push_node(Node {
-            kind: NodeKind::Guard(refine),
-            children: vec![],
-        });
+        self.push_node(Node::Guard(refine, vec![]));
     }
 
-    pub fn push_constraint(&mut self, ty: Ty, refine: Refine) {
-        self.push_binding(Var::Nu, ty);
-        self.push_guard(refine);
-        self.pop_to(self.curr_depth() - 2);
+    pub fn push_pred(&mut self, refine: Refine) {
+        self.push_node(Node::Leaf(refine));
     }
 
     fn push_node(&mut self, node: Node) {
         let curr_node_id = self.curr_node_id();
         let new_node_id = self.nodes.push(node);
-        self.nodes[curr_node_id].children.push(new_node_id);
+        self.nodes[curr_node_id].push_child(new_node_id);
         self.curr_path.push(new_node_id);
     }
 
@@ -90,17 +80,18 @@ impl BindingTree {
     fn check_aux(&self, node_id: NodeId, fixpoint: &mut Fixpoint) -> Constraint {
         let node = &self.nodes[node_id];
 
-        match &node.kind {
-            NodeKind::Blank => {
+        match node {
+            Node::Leaf(refine) => Constraint::Pred(fixpoint.embed(refine)),
+            Node::Blank(children) => {
                 let mut conj = vec![];
 
-                for &node_id in node.children.iter() {
+                for &node_id in children {
                     conj.push(self.check_aux(node_id, fixpoint));
                 }
 
                 bar(conj)
             }
-            NodeKind::Binding(var, ty) => match ty.kind() {
+            Node::Binding(var, ty, children) => match ty.kind() {
                 liquid_rust_lrir::ty::TyKind::Refined(base_ty, refinement) => {
                     fixpoint.push_var(Var::Nu);
                     let refinement = fixpoint.embed(refinement);
@@ -110,9 +101,9 @@ impl BindingTree {
 
                     let mut conj = vec![];
 
-                    fixpoint.push_var(var.clone());
+                    fixpoint.push_var(*var);
 
-                    for &node_id in node.children.iter() {
+                    for &node_id in children {
                         conj.push(self.check_aux(node_id, fixpoint));
                     }
 
@@ -126,21 +117,21 @@ impl BindingTree {
                 liquid_rust_lrir::ty::TyKind::Uninit(_size) => {
                     let mut conj = vec![];
 
-                    for &node_id in node.children.iter() {
+                    for &node_id in children {
                         conj.push(self.check_aux(node_id, fixpoint));
                     }
 
                     bar(conj)
                 }
             },
-            NodeKind::Guard(refine) => {
+            Node::Guard(refine, children) => {
                 let mut conj = vec![Constraint::Pred(fixpoint.embed(refine))];
 
-                for &node_id in node.children.iter() {
+                for &node_id in children {
                     conj.push(self.check_aux(node_id, fixpoint));
                 }
 
-                bar(conj)
+                Constraint::Guard(fixpoint.embed(refine), Box::new(bar(conj)))
             }
         }
     }
@@ -156,15 +147,16 @@ impl BindingTree {
         for (id, node) in self.nodes.iter_enumerated() {
             writeln!(buf, "  \"{:?}\"[", id)?;
 
-            match &node.kind {
-                NodeKind::Blank => writeln!(buf, "    label = \"blank\"")?,
-                NodeKind::Binding(var, ty) => writeln!(buf, "    label = \"{}: {}\"", var, ty)?,
-                NodeKind::Guard(refine) => writeln!(buf, "    label = \"{}\"", refine)?,
+            match &node {
+                Node::Blank(..) => writeln!(buf, "    label = \"blank\"")?,
+                Node::Binding(var, ty, ..) => writeln!(buf, "    label = \"{}: {}\"", var, ty)?,
+                Node::Guard(refine, ..) => writeln!(buf, "    label = \"{}\"", refine)?,
+                Node::Leaf(refine) => writeln!(buf, "    label = \"{}\"", refine)?,
             }
 
             writeln!(buf, "  ];")?;
 
-            for child in node.children.iter() {
+            for child in node.children() {
                 writeln!(buf, "  \"{:?}\" -> \"{:?}\"", id, child)?;
             }
         }
@@ -183,22 +175,40 @@ fn bar(mut conj: Vec<Constraint>) -> Constraint {
     }
 }
 
-struct Node {
-    kind: NodeKind,
-    children: Vec<NodeId>,
+enum Node {
+    Blank(Vec<NodeId>),
+    Binding(Var, Ty, Vec<NodeId>),
+    Guard(Refine, Vec<NodeId>),
+    Leaf(Refine),
 }
 
 impl Node {
-    /// Returns `true` if the node is a [`Binding`].
-    fn is_binding(&self) -> bool {
-        matches!(self.kind, NodeKind::Binding(..))
+    fn children(&self) -> impl Iterator<Item = NodeId> + '_ {
+        let iter = match self {
+            Node::Blank(children) => children.iter(),
+            Node::Binding(_, _, children) => children.iter(),
+            Node::Guard(_, children) => children.iter(),
+            Node::Leaf(_) => [].iter(),
+        };
+        iter.copied()
+    }
+
+    fn push_child(&mut self, child: NodeId) {
+        let children = match self {
+            Node::Blank(children) => children,
+            Node::Binding(_, _, children) => children,
+            Node::Guard(_, children) => children,
+            Node::Leaf(_) => panic!("Trying to push a child into a leaf node."),
+        };
+        children.push(child);
     }
 }
 
-enum NodeKind {
-    Blank,
-    Binding(Var, Ty),
-    Guard(Refine),
+impl Node {
+    /// Returns `true` if the node is [`Binding`].
+    fn is_binding(&self) -> bool {
+        matches!(self, Self::Binding(..))
+    }
 }
 
 impl fmt::Display for BindingTree {
@@ -206,10 +216,10 @@ impl fmt::Display for BindingTree {
         let env = self
             .curr_path
             .iter()
-            .filter_map(|node_id| match &self.nodes[*node_id].kind {
-                NodeKind::Blank => None,
-                NodeKind::Binding(v, ty) => Some(format!("{}: {}", v, ty)),
-                NodeKind::Guard(pred) => Some(format!("{}", pred)),
+            .filter_map(|node_id| match &self.nodes[*node_id] {
+                Node::Binding(v, ty, ..) => Some(format!("{}: {}", v, ty)),
+                Node::Guard(pred, ..) => Some(format!("{}", pred)),
+                _ => None,
             })
             .collect::<Vec<_>>()
             .join(", ");


### PR DESCRIPTION
* Fix uses of guards in the binding tree. Create a new leaf node variant for predicates in the "right hand side".
* Use *two-tier* refinements for constraints to match fixpoint. This fixes problems with parentheses in fixpoint.