### PR TITLE
Add initial polonius infrastructure (fact-loading)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +133,34 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "datafrog"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0afaad2b26fa326569eb264b1363e8ae3357618c43982b3f285f0774ce76b69"
 
 [[package]]
 name = "diff"
@@ -288,12 +328,18 @@ dependencies = [
 name = "liquid-rust-driver"
 version = "0.1.0"
 dependencies = [
+ "csv",
+ "hashconsing",
+ "lazy_static",
  "liquid-rust-common",
  "liquid-rust-lrir",
  "liquid-rust-parser",
  "liquid-rust-typeck",
+ "polonius-engine",
  "quickscope",
+ "regex",
  "rustc-workspace-hack",
+ "serde",
 ]
 
 [[package]]
@@ -380,12 +426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
-name = "once_cell"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
-
-[[package]]
 name = "petgraph"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -409,6 +449,17 @@ name = "pico-args"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d70072c20945e1ab871c472a285fc772aefd4f5407723c206242f2c6f94595d6"
+
+[[package]]
+name = "polonius-engine"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2558a4b464e185b36ee08a2937ebb62ea5464c38856cfb1465c97cb38db52d"
+dependencies = [
+ "datafrog",
+ "log",
+ "rustc-hash",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -463,14 +514,22 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -490,6 +549,12 @@ dependencies = [
  "constant_time_eq",
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-workspace-hack"
@@ -578,15 +643,6 @@ dependencies = [
  "byteorder",
  "dirs",
  "winapi",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]

--- a/liquid-rust-driver/Cargo.toml
+++ b/liquid-rust-driver/Cargo.toml
@@ -12,8 +12,14 @@ liquid-rust-lrir = { path = "../liquid-rust-lrir" }
 liquid-rust-parser = { path = "../liquid-rust-parser" }
 liquid-rust-typeck = { path = "../liquid-rust-typeck" }
 
+csv = "1.1.6"
+hashconsing = "1.3"
+lazy_static = "1.4.0"
+polonius-engine = "0.12.1"
 quickscope = "0.1.6"
+regex = "1.4.5"
 rustc-workspace-hack = "1.0.0"
+serde = "1"
 
 [package.metadata.rust-analyzer]
 rustc_private = true

--- a/liquid-rust-driver/src/borrowck.rs
+++ b/liquid-rust-driver/src/borrowck.rs
@@ -1,0 +1,366 @@
+// This code is adapted from the
+// [Polonius](https://github.com/rust-lang-nursery/polonius/blob/master/src/facts.rs)
+// and [Prusti](https://github.com/viperproject/prusti-dev/blob/master/prusti-interface/src/environment/borrowck/facts.rs)
+// source codes. Since the latter is licensed under MPL, its license is
+// reproduced below:
+//
+// © 2019, ETH Zurich
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! This module defines utilities for interacting with nll facts,
+//! collected during Rust compilation.
+
+use csv::ReaderBuilder;
+use hashconsing::{HConsign, HashConsign};
+use lazy_static::lazy_static;
+use liquid_rust_common::index::newtype_index;
+use polonius_engine;
+use regex::Regex;
+use rustc_index::vec::Idx;
+use rustc_middle::mir;
+use serde::de::{Deserialize, DeserializeOwned, Deserializer};
+use std::{path::Path, str::FromStr};
+
+/// Macro for declaring index types for referencing interned facts.
+macro_rules! index_type {
+    ($typ:ident, $debug_str:ident) => {
+        newtype_index! {
+            pub struct $typ {
+                DEBUG_FORMAT = concat!(stringify!($debug_str), "_{}")
+            }
+        }
+
+        impl InternTo<$typ> for String {
+            fn intern(_interner: &mut Interner, from: String) -> $typ {
+                from.parse().unwrap()
+            }
+        }
+
+        impl polonius_engine::Atom for $typ {
+            fn index(self) -> usize {
+                self.into()
+            }
+        }
+    };
+}
+
+// A unique identifier of a loan.
+index_type!(Loan, L);
+// A unique identifier of a region.
+index_type!(Region, R);
+// A unique identifier of a variable.
+index_type!(Variable, V);
+// A unique identifier of a path.
+index_type!(Place, X);
+
+/// From https://github.com/rust-lang/polonius/blob/master/src/intern.rs:
+/// When we load facts out of the table, they are essentially random
+/// strings. We create an intern table to map those to integers.
+pub struct Interner {
+    pub points: HConsign<Point>,
+}
+
+impl Interner {
+    pub fn new() -> Self {
+        Self {
+            points: HConsign::empty(),
+        }
+    }
+}
+
+pub trait InternTo<To> {
+    fn intern(interner: &mut Interner, input: Self) -> To;
+}
+
+impl<A, FromA, B, FromB> InternTo<(A, B)> for (FromA, FromB)
+where
+    FromA: InternTo<A>,
+    FromB: InternTo<B>,
+{
+    fn intern(tables: &mut Interner, input: (FromA, FromB)) -> (A, B) {
+        let (from_a, from_b) = input;
+        (FromA::intern(tables, from_a), FromB::intern(tables, from_b))
+    }
+}
+
+impl<A, FromA, B, FromB, C, FromC> InternTo<(A, B, C)> for (FromA, FromB, FromC)
+where
+    FromA: InternTo<A>,
+    FromB: InternTo<B>,
+    FromC: InternTo<C>,
+{
+    fn intern(tables: &mut Interner, input: (FromA, FromB, FromC)) -> (A, B, C) {
+        let (from_a, from_b, from_c) = input;
+        (
+            FromA::intern(tables, from_a),
+            FromB::intern(tables, from_b),
+            FromC::intern(tables, from_c),
+        )
+    }
+}
+
+impl<A, FromA, B, FromB, C, FromC, D, FromD> InternTo<(A, B, C, D)> for (FromA, FromB, FromC, FromD)
+where
+    FromA: InternTo<A>,
+    FromB: InternTo<B>,
+    FromC: InternTo<C>,
+    FromD: InternTo<D>,
+{
+    fn intern(tables: &mut Interner, input: (FromA, FromB, FromC, FromD)) -> (A, B, C, D) {
+        let (from_a, from_b, from_c, from_d) = input;
+        (
+            FromA::intern(tables, from_a),
+            FromB::intern(tables, from_b),
+            FromC::intern(tables, from_c),
+            FromD::intern(tables, from_d),
+        )
+    }
+}
+
+/// The type of the point. Either the start of a statement or in the
+/// middle of it.
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum PointType {
+    Start,
+    Mid,
+}
+
+impl std::cmp::PartialOrd for PointType {
+    fn partial_cmp(&self, other: &PointType) -> Option<std::cmp::Ordering> {
+        let res = match (self, other) {
+            (PointType::Start, PointType::Start) => std::cmp::Ordering::Equal,
+            (PointType::Start, PointType::Mid) => std::cmp::Ordering::Less,
+            (PointType::Mid, PointType::Start) => std::cmp::Ordering::Greater,
+            (PointType::Mid, PointType::Mid) => std::cmp::Ordering::Equal,
+        };
+        Some(res)
+    }
+}
+
+impl std::cmp::Ord for PointType {
+    fn cmp(&self, other: &PointType) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+#[derive(Debug)]
+pub struct UnknownPointTypeError(String);
+
+impl FromStr for PointType {
+    type Err = UnknownPointTypeError;
+
+    fn from_str(point_type: &str) -> Result<Self, Self::Err> {
+        match point_type {
+            "Start" => Ok(PointType::Start),
+            "Mid" => Ok(PointType::Mid),
+            _ => Err(UnknownPointTypeError(String::from(point_type))),
+        }
+    }
+}
+
+/// A program point used in the borrow checker analysis.
+#[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Clone)]
+pub struct Point {
+    pub location: mir::Location,
+    pub typ: PointType,
+}
+
+impl std::fmt::Display for Point {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:?}:{:?}:{:?}",
+            self.location.block, self.location.statement_index, self.typ
+        )
+    }
+}
+
+impl FromStr for Point {
+    type Err = ();
+
+    fn from_str(point: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex =
+                Regex::new(r"^(?P<type>Mid|Start)\(bb(?P<bb>\d+)\[(?P<stmt>\d+)\]\)$").unwrap();
+        }
+        let caps = RE.captures(point).unwrap();
+        let point_type: PointType = caps["type"].parse().unwrap();
+        let basic_block: usize = caps["bb"].parse().unwrap();
+        let statement_index: usize = caps["stmt"].parse().unwrap();
+        Ok(Self {
+            location: mir::Location {
+                block: mir::BasicBlock::new(basic_block),
+                statement_index,
+            },
+            typ: point_type,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for Point {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(FromStr::from_str(&s).unwrap())
+    }
+}
+
+newtype_index! {
+    pub struct PointIndex {
+        DEBUG_FORMAT = "pi_{}"
+    }
+}
+
+impl InternTo<PointIndex> for String {
+    fn intern(interner: &mut Interner, input: Self) -> PointIndex {
+        let p = input.parse().unwrap();
+        PointIndex::new(interner.points.mk(p).uid() as usize)
+    }
+}
+
+impl polonius_engine::Atom for PointIndex {
+    fn index(self) -> usize {
+        self.into()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LrFactTypes;
+
+impl polonius_engine::FactTypes for LrFactTypes {
+    type Origin = Region;
+    type Loan = Loan;
+    type Point = PointIndex;
+    type Variable = Variable;
+    type Path = Place;
+}
+
+pub type AllFacts = polonius_engine::AllFacts<LrFactTypes>;
+
+impl FromStr for Region {
+    type Err = ();
+
+    fn from_str(region: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^'_#(?P<id>\d+)r$").unwrap();
+        }
+        println!("{}", region);
+        let caps = RE.captures(region).unwrap();
+        let id: usize = caps["id"].parse().unwrap();
+        Ok(Self::new(id))
+    }
+}
+
+impl FromStr for Loan {
+    type Err = ();
+
+    fn from_str(loan: &str) -> Result<Self, Self::Err> {
+        lazy_static! {
+            static ref RE: Regex = Regex::new(r"^bw(?P<id>\d+)$").unwrap();
+        }
+        let caps = RE.captures(loan).unwrap();
+        let id: usize = caps["id"].parse().unwrap();
+        Ok(Self::new(id))
+    }
+}
+
+impl FromStr for Variable {
+    type Err = ();
+
+    fn from_str(variable: &str) -> Result<Self, Self::Err> {
+        Ok(Self::new(variable[1..].parse().unwrap()))
+    }
+}
+
+impl FromStr for Place {
+    type Err = ();
+
+    fn from_str(place: &str) -> Result<Self, Self::Err> {
+        assert_eq!(place.chars().nth(0).unwrap(), 'm');
+        assert_eq!(place.chars().nth(1).unwrap(), 'p');
+        Ok(Self::new(place[2..].parse().unwrap()))
+    }
+}
+
+pub struct FactLoader {
+    pub interner: Interner,
+    pub facts: AllFacts,
+}
+
+impl FactLoader {
+    pub fn new() -> Self {
+        Self {
+            interner: Interner::new(),
+            facts: AllFacts::default(),
+        }
+    }
+
+    pub fn load_facts<T: DeserializeOwned + InternTo<U>, U>(
+        &mut self,
+        facts_dir: &Path,
+        facts_type: &str,
+    ) -> Vec<U> {
+        let filename = format!("{}.facts", facts_type);
+        let facts_file = facts_dir.join(&filename);
+        let mut reader = ReaderBuilder::new()
+            .delimiter(b'\t')
+            .has_headers(false)
+            .from_path(&facts_file)
+            .unwrap_or_else(|err| panic!("failed to read file {:?} with err: {}", facts_file, err));
+
+        let mut res: Vec<U> = vec![];
+
+        for row in reader.deserialize() {
+            let row: T = row.unwrap();
+            res.push(InternTo::intern(&mut self.interner, row))
+        }
+
+        res
+    }
+
+    pub fn load_all_facts(&mut self, facts_dir: &Path) {
+        macro_rules! add {
+            ($cols:ty, $fact_type:ident) => {
+                let f = self.load_facts::<$cols, _>(facts_dir, stringify!($fact_type));
+                self.facts.$fact_type.extend(f);
+            };
+            ($cols:ty, $res:ty, $fact_type:ident) => {
+                let f = self.load_facts::<$cols, $res>(facts_dir, stringify!($fact_type));
+                self.facts.$fact_type.extend(f);
+            };
+        }
+
+        add!(String, Region, universal_region);
+
+        add!((String, String), cfg_edge);
+        add!((String, String), killed);
+        add!((String, String), invalidates);
+        add!((String, String), var_used_at);
+        add!((String, String), var_defined_at);
+        add!((String, String), var_dropped_at);
+        add!((String, String), use_of_var_derefs_origin);
+        add!((String, String), drop_of_var_derefs_origin);
+        add!((String, String), child_path);
+        add!((String, String), path_is_var);
+        add!((String, String), path_assigned_at_base);
+        add!((String, String), path_moved_at_base);
+        add!((String, String), path_accessed_at_base);
+        add!((String, String), known_subset);
+        add!((String, String), placeholder);
+
+        add!((String, String, String), borrow_region);
+        add!((String, String, String), outlives);
+    }
+}
+
+pub fn load_facts(facts_dir: &Path) -> FactLoader {
+    let mut fl = FactLoader::new();
+    fl.load_all_facts(facts_dir);
+    fl
+}
+

--- a/liquid-rust-driver/src/lib.rs
+++ b/liquid-rust-driver/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(rustc_private)]
 #![feature(box_patterns)]
+#![feature(const_panic)]
 
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
@@ -10,8 +11,10 @@ extern crate rustc_index;
 extern crate rustc_interface;
 extern crate rustc_middle;
 extern crate rustc_mir;
+extern crate rustc_serialize;
 extern crate rustc_span;
 
+pub mod borrowck;
 mod callbacks;
 mod collector;
 mod lower;

--- a/liquid-rust-driver/tests/fail/mod.rs
+++ b/liquid-rust-driver/tests/fail/mod.rs
@@ -9,6 +9,7 @@ macro_rules! fail_test {
             let path = concat!("tests/fail/", stringify!($name), ".rs");
             let code = liquid_rust_driver::run_compiler(vec![
                 "whatever".into(),
+                "-Znll-facts".into(),
                 path.into(),
                 sysroot.into(),
                 "--crate-type=lib".into(),

--- a/liquid-rust-driver/tests/mod.rs
+++ b/liquid-rust-driver/tests/mod.rs
@@ -1,3 +1,3 @@
-mod pass;
 mod fail;
+mod pass;
 mod todo;

--- a/liquid-rust-driver/tests/pass/mod.rs
+++ b/liquid-rust-driver/tests/pass/mod.rs
@@ -10,6 +10,7 @@ macro_rules! pass_test {
 
             let code = liquid_rust_driver::run_compiler(vec![
                 "whatever".into(),
+                "-Znll-facts".into(),
                 path.into(),
                 sysroot.into(),
                 "-O".into(),

--- a/liquid-rust-driver/tests/todo/mod.rs
+++ b/liquid-rust-driver/tests/todo/mod.rs
@@ -11,6 +11,7 @@ macro_rules! todo_test {
 
             liquid_rust_driver::run_compiler(vec![
                 "whatever".into(),
+                "-Znll-facts".into(),
                 path.into(),
                 sysroot.into(),
                 "--crate-type=lib".into(),

--- a/liquid-rust/src/main.rs
+++ b/liquid-rust/src/main.rs
@@ -14,6 +14,8 @@ fn main() {
     // Add the sysroot path to the arguments.
     args.push("--sysroot".into());
     args.push(sysroot().expect("Liquid Rust requires rustup to be built."));
+    // Record nll-facts for this compilation.
+    args.push("-Znll-facts".into());
     // Add release mode to the arguments.
     args.push("-O".into());
     // Run the rust compiler with the arguments.


### PR DESCRIPTION
Note: the code in `liquid-rust-driver/src/borrowck.rs` is adapted partly from Prusti's code, which is licensed under MPL. The code in that file also carries the same license.