### PR TITLE
Assert terminator support

### DIFF
--- a/liquid-rust-core/src/ir.rs
+++ b/liquid-rust-core/src/ir.rs
@@ -53,6 +53,11 @@ pub enum TerminatorKind {
         place: Place,
         target: BasicBlock,
     },
+    Assert {
+        cond: Operand,
+        expected: bool,
+        target: BasicBlock,
+    },
 }
 
 pub struct Statement {
@@ -191,6 +196,9 @@ impl fmt::Debug for Terminator {
             }
             TerminatorKind::Drop { place, target } => {
                 write!(f, "drop({:?}) -> {:?}", place, target)
+            }
+            TerminatorKind::Assert { cond, target, expected } => {
+                write!(f, "Assert({:?} is expected to be {:?}) -> {:?}", cond, expected, target)
             }
         }
     }

--- a/liquid-rust-core/src/ir.rs
+++ b/liquid-rust-core/src/ir.rs
@@ -198,7 +198,7 @@ impl fmt::Debug for Terminator {
                 write!(f, "drop({:?}) -> {:?}", place, target)
             }
             TerminatorKind::Assert { cond, target, expected } => {
-                write!(f, "Assert({:?} is expected to be {:?}) -> {:?}", cond, expected, target)
+                write!(f, "assert({:?} is expected to be {:?}) -> {:?}", cond, expected, target)
             }
         }
     }

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -135,11 +135,17 @@ impl<'tcx> LoweringCtxt<'tcx> {
                 place: self.lower_place(place)?,
                 target: *target,
             },
+            mir::TerminatorKind::Assert { cond, target, expected, .. } => {
+                TerminatorKind::Assert {
+                    cond: self.lower_operand(cond)?,
+                    expected: *expected,
+                    target: *target,
+                }
+            },
             mir::TerminatorKind::Resume
             | mir::TerminatorKind::Abort
             | mir::TerminatorKind::Unreachable
             | mir::TerminatorKind::DropAndReplace { .. }
-            | mir::TerminatorKind::Assert { .. }
             | mir::TerminatorKind::Yield { .. }
             | mir::TerminatorKind::GeneratorDrop
             | mir::TerminatorKind::FalseEdge { .. }

--- a/liquid-rust-driver/tests/neg.rs
+++ b/liquid-rust-driver/tests/neg.rs
@@ -5,4 +5,6 @@ tests! {
     test01: "../tests/neg/test01.rs" => Unsafe,
     test02: "../tests/neg/test02.rs" => Unsafe,
     test03: "../tests/neg/test03.rs" => Unsafe,
+    // Note: only fails if line 329 of liquid-rust-typeck/src/checker.rs is uncommented
+    // assert_terminator: "../tests/neg/assert_terminator.rs" => Unsafe,
 }

--- a/liquid-rust-driver/tests/pos.rs
+++ b/liquid-rust-driver/tests/pos.rs
@@ -6,4 +6,5 @@ tests! {
     test02: "../tests/pos/test02.rs" => Safe,
     test03: "../tests/pos/test03.rs" => Safe,
     heapsort: "../tests/pos/heapsort.rs" => Safe,
+    assert_terminator: "../tests/pos/assert_terminator.rs" => Safe,
 }

--- a/liquid-rust-typeck/src/checker.rs
+++ b/liquid-rust-typeck/src/checker.rs
@@ -229,7 +229,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
                 )?;
             }
             TerminatorKind::Assert { cond, expected, target } => {
-                self.check_assert(env, cursor, cond, expected, *target)?;
+                self.check_assert(env, cursor, cond, *expected, *target)?;
             }
             TerminatorKind::Drop { place, target } => {
                 let _ = env.move_place(place);
@@ -322,7 +322,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
             _ => unreachable!("unexpected cond_ty {:?}", cond_ty),
         };
 
-        let assert = if cond { pred } else { pred.not() }
+        let assert = if expected { pred } else { pred.not() };
 
         // Uncomment the below line to allow pre-catching of possible divide-by-zero, underflow, and overflow
         // WARNING: rust is very eager about inserting under/overflow checks, so be warned that uncommenting this will likely break everything

--- a/liquid-rust-typeck/src/checker.rs
+++ b/liquid-rust-typeck/src/checker.rs
@@ -310,7 +310,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
         env: &mut TypeEnv<'tcx>,
         cursor: &mut Cursor,
         cond: &Operand,
-        expected: &bool,
+        expected: bool,
         target: BasicBlock,
     ) -> Result<(), ErrorReported> {
         let cond_ty = self.check_operand(env, cond);
@@ -322,7 +322,7 @@ impl<'a, 'tcx> Checker<'a, 'tcx> {
             _ => unreachable!("unexpected cond_ty {:?}", cond_ty),
         };
 
-        let assert = ExprKind::BinaryOp(BinOp::Eq, pred, ExprKind::Constant(liquid_rust_fixpoint::Constant::Bool(*expected)).intern()).intern();
+        let assert = if cond { pred } else { pred.not() }
 
         // Uncomment the below line to allow pre-catching of possible divide-by-zero, underflow, and overflow
         // WARNING: rust is very eager about inserting under/overflow checks, so be warned that uncommenting this will likely break everything

--- a/tests/neg/assert_terminator.rs
+++ b/tests/neg/assert_terminator.rs
@@ -1,0 +1,9 @@
+#![feature(register_tool)]
+#![register_tool(lr)]
+
+// Note: only fails if line 329 of liquid-rust-typeck/src/checker.rs is uncommented
+#[lr::ty(fn(usize, usize) -> usize)]
+pub fn assert_terminator_test(a: usize, b: usize) -> usize {
+    let x = a / b;
+    x
+}

--- a/tests/pos/assert_terminator.rs
+++ b/tests/pos/assert_terminator.rs
@@ -1,0 +1,8 @@
+#![feature(register_tool)]
+#![register_tool(lr)]
+
+#[lr::ty(fn(usize, usize{x: x > 0}) -> usize)]
+pub fn assert_terminator_test(a: usize, b: usize) -> usize {
+    let x = a / b;
+    x
+}


### PR DESCRIPTION
Assert, a terminator in rust's mir, seems to be generated for under/overflow checking, as well as checking for div-by-zero. This includes supporting it essentially as a guarded goto, but also demonstrates the code needed to validate the absence of possible assert failures.