### PR TITLE
Add representation of qualifiers to fixpoint syntax

### DIFF
--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -92,6 +92,8 @@ newtype_index! {
 newtype_index! {
     pub struct Name {
         DEBUG_FORMAT = "a{}",
+        const NAME0 = 0,
+        const NAME1 = 1,
     }
 }
 
@@ -182,6 +184,11 @@ impl fmt::Display for Pred {
     }
 }
 
+impl Expr {
+    pub const ZERO: Expr = Expr::Constant(Constant::ZERO);
+    pub const ONE: Expr = Expr::Constant(Constant::ONE);
+}
+
 impl fmt::Display for Expr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn should_parenthesize(op: BinOp, child: &Expr) -> bool {
@@ -224,115 +231,110 @@ impl fmt::Display for Expr {
 
 impl Qualifier {
     pub fn get_defaults() -> Vec<Self> {
-        let name1: Name = Name::from(0 as usize);
-        let name2: Name = Name::from(1 as usize);
-
         // Unary
-        let un_op_names = vec![(name1, Sort::Int)];
 
-        // writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
+        // (qualif EqZero ((v int)) (v == 0))
         let eqzero = Qualifier {
-            args: un_op_names.clone(),
+            args: vec![(NAME0, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Eq,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
+                Box::new(Expr::Var(NAME0)),
+                Box::new(Expr::ZERO),
             ),
             name: String::from("EqZero"),
         };
 
-        // writeln!(f, "(qualif GtZero ((v int)) (v > 0))")?;
+        // (qualif GtZero ((v int)) (v > 0))
         let gtzero = Qualifier {
-            args: un_op_names.clone(),
+            args: vec![(NAME0, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Gt,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
+                Box::new(Expr::Var(NAME0)),
+                Box::new(Expr::ZERO),
             ),
             name: String::from("GtZero"),
         };
 
-        // writeln!(f, "(qualif GeZero ((v int)) (v >= 0))")?;
+        // (qualif GeZero ((v int)) (v >= 0))
         let gezero = Qualifier {
-            args: un_op_names.clone(),
+            args: vec![(NAME0, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Ge,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
+                Box::new(Expr::Var(NAME0)),
+                Box::new(Expr::ZERO),
             ),
             name: String::from("GeZero"),
         };
 
-        // writeln!(f, "(qualif LtZero ((v int)) (v < 0))")?;
+        // (qualif LtZero ((v int)) (v < 0))
         let ltzero = Qualifier {
-            args: un_op_names.clone(),
+            args: vec![(NAME0, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Lt,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
+                Box::new(Expr::Var(NAME0)),
+                Box::new(Expr::ZERO),
             ),
             name: String::from("LtZero"),
         };
 
-        // writeln!(f, "(qualif LeZero ((v int)) (v <= 0))")?;
+        // (qualif LeZero ((v int)) (v <= 0))
         let lezero = Qualifier {
-            args: un_op_names.clone(),
+            args: vec![(NAME0, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Le,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
+                Box::new(Expr::Var(NAME0)),
+                Box::new(Expr::ZERO),
             ),
             name: String::from("LeZero"),
         };
 
         // Binary
-        let bin_op_names = vec![(name1, Sort::Int), (name2, Sort::Int)];
 
-        // writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
+        // (qualif Eq ((a int) (b int)) (a == b))
         let eq = Qualifier {
-            args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
+            expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
             name: String::from("Eq"),
         };
 
-        // writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
+        // (qualif Gt ((a int) (b int)) (a > b))
         let gt = Qualifier {
-            args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
+            expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
             name: String::from("Gt"),
         };
 
-        // writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
+        // (qualif Lt ((a int) (b int)) (a < b))
         let ge = Qualifier {
-            args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
+            expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
             name: String::from("Ge"),
         };
 
-        // writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
+        // (qualif Ge ((a int) (b int)) (a >= b))
         let lt = Qualifier {
-            args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
+            expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
             name: String::from("Lt"),
         };
 
-        // writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
+        // (qualif Le ((a int) (b int)) (a <= b))
         let le = Qualifier {
-            args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
+            expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(NAME0)), Box::new(Expr::Var(NAME1))),
             name: String::from("Le"),
         };
 
-        // writeln!(f, "(qualif Le1 ((a int) (b int)) (a < b - 1))")?;
+        // (qualif Le1 ((a int) (b int)) (a < b - 1))
         let le1 = Qualifier {
-            args: bin_op_names.clone(),
+            args: vec![(NAME0, Sort::Int), (NAME1, Sort::Int)],
             expr: Expr::BinaryOp(
                 BinOp::Le,
-                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(NAME0)),
                 Box::new(Expr::BinaryOp(
                     BinOp::Sub,
-                    Box::new(Expr::Var(name2)),
-                    Box::new(Expr::Constant(Constant::Int(Sign::Positive, 1))),
+                    Box::new(Expr::Var(NAME1)),
+                    Box::new(Expr::ONE),
                 )),
             ),
             name: String::from("Le1"),
@@ -344,8 +346,6 @@ impl Qualifier {
 
 impl fmt::Display for Qualifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        //writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
-
         let name_list = self
             .args
             .iter()
@@ -399,6 +399,7 @@ impl fmt::Display for Constant {
 
 impl Constant {
     pub const ZERO: Constant = Constant::Int(Sign::Positive, 0);
+    pub const ONE: Constant = Constant::Int(Sign::Positive, 1);
 }
 
 impl From<u128> for Constant {

--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -29,6 +29,12 @@ pub enum Expr {
     UnaryOp(UnOp, Box<Self>),
 }
 
+pub struct Qualifier {
+    expr: Expr,
+    free_vars: Vec<(Name, Sort)>,
+    name: String,
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BinOp {
     Iff,
@@ -213,6 +219,69 @@ impl fmt::Display for Expr {
                 }
             }
         }
+    }
+}
+
+impl Qualifier {
+    pub fn get_defaults() -> Vec<Self> {
+        let name1: Name = Name::from(0 as usize);
+        let name2: Name = Name::from(1 as usize);
+        let un_op_names = vec!((name1, Sort::Int));
+        let bin_op_names = vec!((name1, Sort::Int), (name2, Sort::Int));
+        // writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
+        let eqzero = Qualifier {
+            free_vars: un_op_names,
+            expr: Expr::BinaryOp(
+                BinOp::Eq,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+            ),
+            name: String::from("EqZero"),
+        };
+
+        // writeln!(f, "(qualif Le1 ((a int) (b int)) (a < b - 1))")?;
+        let le1 = Qualifier {
+            free_vars: bin_op_names,
+            expr: Expr::BinaryOp(
+                BinOp::Le,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::BinaryOp(
+                    BinOp::Sub,
+                    Box::new(Expr::Var(name2)),
+                    Box::new(Expr::Constant(Constant::Int(Sign::Positive, 1)))
+                )),
+            ),
+            name: String::from("Le1"),
+        };
+
+        // Todo: write up the rest of these, the above two are only there as tests/examples
+        /*
+        writeln!(f, "(qualif GtZero ((v int)) (v > 0))")?;
+        writeln!(f, "(qualif GeZero ((v int)) (v >= 0))")?;
+        writeln!(f, "(qualif LtZero ((v int)) (v < 0))")?;
+        writeln!(f, "(qualif LeZero ((v int)) (v <= 0))")?;
+
+        // Binary
+        writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
+        writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
+        writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
+        writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
+        writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
+        */
+
+        vec!(eqzero, le1)
+    }
+}
+
+impl fmt::Display for Qualifier {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        //writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
+
+        let name_list = self.free_vars.iter().map(|(name, sort)| {
+            format!("({:?} {})", name, sort)
+        }).join(&String::from(" "));
+
+        write!(f, "(qualif {} ({}) ({}))", self.name, name_list, self.expr)
     }
 }
 

--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -228,7 +228,7 @@ impl Qualifier {
         let name2: Name = Name::from(1 as usize);
 
         // Unary
-        let un_op_names = vec!((name1, Sort::Int));
+        let un_op_names = vec![(name1, Sort::Int)];
 
         // writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
         let eqzero = Qualifier {
@@ -236,7 +236,7 @@ impl Qualifier {
             expr: Expr::BinaryOp(
                 BinOp::Eq,
                 Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
             ),
             name: String::from("EqZero"),
         };
@@ -247,7 +247,7 @@ impl Qualifier {
             expr: Expr::BinaryOp(
                 BinOp::Gt,
                 Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
             ),
             name: String::from("GtZero"),
         };
@@ -258,7 +258,7 @@ impl Qualifier {
             expr: Expr::BinaryOp(
                 BinOp::Ge,
                 Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
             ),
             name: String::from("GeZero"),
         };
@@ -269,7 +269,7 @@ impl Qualifier {
             expr: Expr::BinaryOp(
                 BinOp::Lt,
                 Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
             ),
             name: String::from("LtZero"),
         };
@@ -280,66 +280,46 @@ impl Qualifier {
             expr: Expr::BinaryOp(
                 BinOp::Le,
                 Box::new(Expr::Var(name1)),
-                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0))),
             ),
             name: String::from("LeZero"),
         };
 
         // Binary
-        let bin_op_names = vec!((name1, Sort::Int), (name2, Sort::Int));
+        let bin_op_names = vec![(name1, Sort::Int), (name2, Sort::Int)];
 
         // writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
         let eq = Qualifier {
             args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(
-                BinOp::Eq,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Var(name2)),
-            ),
+            expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
             name: String::from("Eq"),
         };
 
         // writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
         let gt = Qualifier {
             args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(
-                BinOp::Gt,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Var(name2)),
-            ),
+            expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
             name: String::from("Gt"),
         };
 
         // writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
         let ge = Qualifier {
             args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(
-                BinOp::Ge,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Var(name2)),
-            ),
+            expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
             name: String::from("Ge"),
         };
 
         // writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
         let lt = Qualifier {
             args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(
-                BinOp::Lt,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Var(name2)),
-            ),
+            expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
             name: String::from("Lt"),
         };
 
         // writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
         let le = Qualifier {
             args: bin_op_names.clone(),
-            expr: Expr::BinaryOp(
-                BinOp::Le,
-                Box::new(Expr::Var(name1)),
-                Box::new(Expr::Var(name2)),
-            ),
+            expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(name1)), Box::new(Expr::Var(name2))),
             name: String::from("Le"),
         };
 
@@ -352,13 +332,13 @@ impl Qualifier {
                 Box::new(Expr::BinaryOp(
                     BinOp::Sub,
                     Box::new(Expr::Var(name2)),
-                    Box::new(Expr::Constant(Constant::Int(Sign::Positive, 1)))
+                    Box::new(Expr::Constant(Constant::Int(Sign::Positive, 1))),
                 )),
             ),
             name: String::from("Le1"),
         };
 
-        vec!(eqzero, gtzero, gezero, ltzero, lezero, eq, gt, ge, lt, le, le1)
+        vec![eqzero, gtzero, gezero, ltzero, lezero, eq, gt, ge, lt, le, le1]
     }
 }
 
@@ -366,9 +346,11 @@ impl fmt::Display for Qualifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
 
-        let name_list = self.args.iter().map(|(name, sort)| {
-            format!("({:?} {})", name, sort)
-        }).join(&String::from(" "));
+        let name_list = self
+            .args
+            .iter()
+            .map(|(name, sort)| format!("({:?} {})", name, sort))
+            .join(&String::from(" "));
 
         write!(f, "(qualif {} ({}) ({}))", self.name, name_list, self.expr)
     }

--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -31,7 +31,7 @@ pub enum Expr {
 
 pub struct Qualifier {
     expr: Expr,
-    free_vars: Vec<(Name, Sort)>,
+    args: Vec<(Name, Sort)>,
     name: String,
 }
 
@@ -226,11 +226,13 @@ impl Qualifier {
     pub fn get_defaults() -> Vec<Self> {
         let name1: Name = Name::from(0 as usize);
         let name2: Name = Name::from(1 as usize);
+
+        // Unary
         let un_op_names = vec!((name1, Sort::Int));
-        let bin_op_names = vec!((name1, Sort::Int), (name2, Sort::Int));
+
         // writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
         let eqzero = Qualifier {
-            free_vars: un_op_names,
+            args: un_op_names.clone(),
             expr: Expr::BinaryOp(
                 BinOp::Eq,
                 Box::new(Expr::Var(name1)),
@@ -239,9 +241,111 @@ impl Qualifier {
             name: String::from("EqZero"),
         };
 
+        // writeln!(f, "(qualif GtZero ((v int)) (v > 0))")?;
+        let gtzero = Qualifier {
+            args: un_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Gt,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+            ),
+            name: String::from("GtZero"),
+        };
+
+        // writeln!(f, "(qualif GeZero ((v int)) (v >= 0))")?;
+        let gezero = Qualifier {
+            args: un_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Ge,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+            ),
+            name: String::from("GeZero"),
+        };
+
+        // writeln!(f, "(qualif LtZero ((v int)) (v < 0))")?;
+        let ltzero = Qualifier {
+            args: un_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Lt,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+            ),
+            name: String::from("LtZero"),
+        };
+
+        // writeln!(f, "(qualif LeZero ((v int)) (v <= 0))")?;
+        let lezero = Qualifier {
+            args: un_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Le,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Constant(Constant::Int(Sign::Positive, 0)))
+            ),
+            name: String::from("LeZero"),
+        };
+
+        // Binary
+        let bin_op_names = vec!((name1, Sort::Int), (name2, Sort::Int));
+
+        // writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
+        let eq = Qualifier {
+            args: bin_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Eq,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(name2)),
+            ),
+            name: String::from("Eq"),
+        };
+
+        // writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
+        let gt = Qualifier {
+            args: bin_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Gt,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(name2)),
+            ),
+            name: String::from("Gt"),
+        };
+
+        // writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
+        let ge = Qualifier {
+            args: bin_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Ge,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(name2)),
+            ),
+            name: String::from("Ge"),
+        };
+
+        // writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
+        let lt = Qualifier {
+            args: bin_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Lt,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(name2)),
+            ),
+            name: String::from("Lt"),
+        };
+
+        // writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
+        let le = Qualifier {
+            args: bin_op_names.clone(),
+            expr: Expr::BinaryOp(
+                BinOp::Le,
+                Box::new(Expr::Var(name1)),
+                Box::new(Expr::Var(name2)),
+            ),
+            name: String::from("Le"),
+        };
+
         // writeln!(f, "(qualif Le1 ((a int) (b int)) (a < b - 1))")?;
         let le1 = Qualifier {
-            free_vars: bin_op_names,
+            args: bin_op_names.clone(),
             expr: Expr::BinaryOp(
                 BinOp::Le,
                 Box::new(Expr::Var(name1)),
@@ -254,22 +358,7 @@ impl Qualifier {
             name: String::from("Le1"),
         };
 
-        // Todo: write up the rest of these, the above two are only there as tests/examples
-        /*
-        writeln!(f, "(qualif GtZero ((v int)) (v > 0))")?;
-        writeln!(f, "(qualif GeZero ((v int)) (v >= 0))")?;
-        writeln!(f, "(qualif LtZero ((v int)) (v < 0))")?;
-        writeln!(f, "(qualif LeZero ((v int)) (v <= 0))")?;
-
-        // Binary
-        writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
-        writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
-        writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
-        writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
-        writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
-        */
-
-        vec!(eqzero, le1)
+        vec!(eqzero, gtzero, gezero, ltzero, lezero, eq, gt, ge, lt, le, le1)
     }
 }
 
@@ -277,7 +366,7 @@ impl fmt::Display for Qualifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         //writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
 
-        let name_list = self.free_vars.iter().map(|(name, sort)| {
+        let name_list = self.args.iter().map(|(name, sort)| {
             format!("({:?} {})", name, sort)
         }).join(&String::from(" "));
 

--- a/liquid-rust-fixpoint/src/constraint.rs
+++ b/liquid-rust-fixpoint/src/constraint.rs
@@ -236,55 +236,35 @@ impl Qualifier {
         // (qualif EqZero ((v int)) (v == 0))
         let eqzero = Qualifier {
             args: vec![(NAME0, Sort::Int)],
-            expr: Expr::BinaryOp(
-                BinOp::Eq,
-                Box::new(Expr::Var(NAME0)),
-                Box::new(Expr::ZERO),
-            ),
+            expr: Expr::BinaryOp(BinOp::Eq, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
             name: String::from("EqZero"),
         };
 
         // (qualif GtZero ((v int)) (v > 0))
         let gtzero = Qualifier {
             args: vec![(NAME0, Sort::Int)],
-            expr: Expr::BinaryOp(
-                BinOp::Gt,
-                Box::new(Expr::Var(NAME0)),
-                Box::new(Expr::ZERO),
-            ),
+            expr: Expr::BinaryOp(BinOp::Gt, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
             name: String::from("GtZero"),
         };
 
         // (qualif GeZero ((v int)) (v >= 0))
         let gezero = Qualifier {
             args: vec![(NAME0, Sort::Int)],
-            expr: Expr::BinaryOp(
-                BinOp::Ge,
-                Box::new(Expr::Var(NAME0)),
-                Box::new(Expr::ZERO),
-            ),
+            expr: Expr::BinaryOp(BinOp::Ge, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
             name: String::from("GeZero"),
         };
 
         // (qualif LtZero ((v int)) (v < 0))
         let ltzero = Qualifier {
             args: vec![(NAME0, Sort::Int)],
-            expr: Expr::BinaryOp(
-                BinOp::Lt,
-                Box::new(Expr::Var(NAME0)),
-                Box::new(Expr::ZERO),
-            ),
+            expr: Expr::BinaryOp(BinOp::Lt, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
             name: String::from("LtZero"),
         };
 
         // (qualif LeZero ((v int)) (v <= 0))
         let lezero = Qualifier {
             args: vec![(NAME0, Sort::Int)],
-            expr: Expr::BinaryOp(
-                BinOp::Le,
-                Box::new(Expr::Var(NAME0)),
-                Box::new(Expr::ZERO),
-            ),
+            expr: Expr::BinaryOp(BinOp::Le, Box::new(Expr::Var(NAME0)), Box::new(Expr::ZERO)),
             name: String::from("LeZero"),
         };
 

--- a/liquid-rust-fixpoint/src/lib.rs
+++ b/liquid-rust-fixpoint/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     str::FromStr,
 };
 
-pub use constraint::{BinOp, Constant, Constraint, Expr, KVid, Name, Pred, Sort, UnOp};
+pub use constraint::{BinOp, Constant, Constraint, Expr, KVid, Name, Pred, Sort, UnOp, Qualifier};
 use itertools::Itertools;
 use liquid_rust_common::format::PadAdapter;
 use serde::{de, Deserialize};
@@ -83,21 +83,10 @@ impl<Tag: fmt::Display + FromStr> Task<Tag> {
 
 impl<Tag: fmt::Display> fmt::Display for Task<Tag> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Unary
-        writeln!(f, "(qualif EqZero ((v int)) (v == 0))")?;
-        writeln!(f, "(qualif GtZero ((v int)) (v > 0))")?;
-        writeln!(f, "(qualif GeZero ((v int)) (v >= 0))")?;
-        writeln!(f, "(qualif LtZero ((v int)) (v < 0))")?;
-        writeln!(f, "(qualif LeZero ((v int)) (v <= 0))")?;
-
-        // Binary
-        writeln!(f, "(qualif Eq ((a int) (b int)) (a == b))")?;
-        writeln!(f, "(qualif Gt ((a int) (b int)) (a > b))")?;
-        writeln!(f, "(qualif Lt ((a int) (b int)) (a < b))")?;
-        writeln!(f, "(qualif Ge ((a int) (b int)) (a >= b))")?;
-        writeln!(f, "(qualif Le ((a int) (b int)) (a <= b))")?;
-        writeln!(f, "(qualif Le1 ((a int) (b int)) (a < b - 1))")?;
         // writeln!(f, "(qualif Foo ((a int) (b int)) (a <= b/2))")?;
+        for qualif in Qualifier::get_defaults() {
+            writeln!(f, "{}", qualif)?;
+        }
 
         for kvar in &self.kvars {
             writeln!(f, "{}", kvar)?;

--- a/liquid-rust-fixpoint/src/lib.rs
+++ b/liquid-rust-fixpoint/src/lib.rs
@@ -11,7 +11,7 @@ use std::{
     str::FromStr,
 };
 
-pub use constraint::{BinOp, Constant, Constraint, Expr, KVid, Name, Pred, Sort, UnOp, Qualifier};
+pub use constraint::{BinOp, Constant, Constraint, Expr, KVid, Name, Pred, Qualifier, Sort, UnOp};
 use itertools::Itertools;
 use liquid_rust_common::format::PadAdapter;
 use serde::{de, Deserialize};


### PR DESCRIPTION
Adds a representation of qualifiers to the fixpoint library using the Qualifier struct, which includes formatting. Replaces hard-coded qualifiers represented as strings with a list of default qualifiers using the new representation.