### PR TITLE
Make types in typeck look more like in the paper

### DIFF
--- a/liquid-rust-typeck/src/checker.rs
+++ b/liquid-rust-typeck/src/checker.rs
@@ -19,7 +19,9 @@ use crate::{
     lowering::LoweringCtxt,
     pure_ctxt::{ConstraintBuilder, KVarStore, PureCtxt, Snapshot},
     subst::Subst,
-    ty::{self, BaseTy, BinOp, Constr, Expr, FnSig, Name, Param, Pred, Sort, Ty, TyKind, Var},
+    ty::{
+        self, BaseTy, BinOp, Constr, Expr, FnSig, Name, Param, Pred, RefMode, Sort, Ty, TyKind, Var,
+    },
     type_env::{BasicBlockEnv, TypeEnv, TypeEnvInfer},
 };
 use itertools::Itertools;
@@ -343,7 +345,8 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
         // Check preconditions
         let mut gen = ConstraintGen::new(self.genv, pcx.breadcrumb(), Tag::Call(source_info.span));
         for (actual, formal) in iter::zip(actuals, &fn_sig.args) {
-            if let (TyKind::StrgRef(path), TyKind::WeakRef(bound)) = (actual.kind(), formal.kind())
+            if let (TyKind::Ptr(path), TyKind::Ref(RefMode::Mut, bound)) =
+                (actual.kind(), formal.kind())
             {
                 env.weaken_ty_at_path(&mut gen, path, bound.clone());
             } else {

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -7,7 +7,7 @@ use rustc_span::Span;
 use crate::{
     global_env::{GlobalEnv, Variance},
     pure_ctxt::PureCtxt,
-    ty::{BaseTy, BinOp, Constr, Expr, Loc, Pred, Ty, TyKind},
+    ty::{BaseTy, BinOp, Constr, Expr, Loc, Pred, RefMode, Ty, TyKind},
     type_env::TypeEnv,
 };
 
@@ -87,14 +87,14 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
                 ck.bty_subtyping(bty1, bty2);
                 ck.check_pred(p.subst_bound_vars(exprs));
             }
-            (TyKind::StrgRef(loc1), TyKind::StrgRef(loc2)) => {
+            (TyKind::Ptr(loc1), TyKind::Ptr(loc2)) => {
                 assert_eq!(loc1, loc2);
             }
-            (TyKind::WeakRef(ty1), TyKind::WeakRef(ty2)) => {
+            (TyKind::Ref(RefMode::Mut, ty1), TyKind::Ref(RefMode::Mut, ty2)) => {
                 ck.subtyping(ty1, ty2);
                 ck.subtyping(ty2, ty1);
             }
-            (TyKind::ShrRef(ty1), TyKind::ShrRef(ty2)) => {
+            (TyKind::Ref(RefMode::Shr, ty1), TyKind::Ref(RefMode::Shr, ty2)) => {
                 ck.subtyping(ty1, ty2);
             }
             (_, TyKind::Uninit(_)) => {

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -133,8 +133,10 @@ impl LoweringCtxt {
                 ty::Ty::exists(bty, pred)
             }
             core::Ty::StrgRef(loc) => ty::Ty::strg_ref(ty::Loc::Free(self.name_map[&loc.name])),
-            core::Ty::WeakRef(ty) => ty::Ty::weak_ref(self.lower_ty(ty, fresh_kvar)),
-            core::Ty::ShrRef(ty) => ty::Ty::shr_ref(self.lower_ty(ty, fresh_kvar)),
+            core::Ty::WeakRef(ty) => {
+                ty::Ty::mk_ref(ty::RefMode::Mut, self.lower_ty(ty, fresh_kvar))
+            }
+            core::Ty::ShrRef(ty) => ty::Ty::mk_ref(ty::RefMode::Shr, self.lower_ty(ty, fresh_kvar)),
             core::Ty::Param(param) => ty::Ty::param(*param),
             core::Ty::Float(float_ty) => ty::Ty::float(*float_ty),
         }


### PR DESCRIPTION
* Rename `Ref` to `Ptr`
* Introduce `RefMode` and make `ShrRef` and `WeakRef` into the same `Ref` variant
* Prefer `mut` instead of `weak` 