### PR TITLE
Support for unit

### DIFF
--- a/liquid-rust-core/src/desugar.rs
+++ b/liquid-rust-core/src/desugar.rs
@@ -191,6 +191,7 @@ impl<'a> DesugarCtxt<'a> {
                 self.requires.push(Constr::Type(loc, ty));
                 Ty::Ptr(loc)
             }
+            surface::TyKind::Unit => Ty::Tuple(vec![]),
         };
         Ok(ty)
     }
@@ -378,7 +379,9 @@ impl ParamsCtxt<'_> {
             surface::TyKind::StrgRef(_, ty) | surface::TyKind::Ref(_, ty) => {
                 self.ty_gather_params(ty, adt_sorts)
             }
-            surface::TyKind::Path(_) | surface::TyKind::Exists { .. } => Ok(()),
+            surface::TyKind::Path(_) | surface::TyKind::Exists { .. } | surface::TyKind::Unit => {
+                Ok(())
+            }
         }
     }
 

--- a/liquid-rust-core/src/ty.rs
+++ b/liquid-rust-core/src/ty.rs
@@ -63,9 +63,10 @@ pub enum Ty {
     Ptr(Ident),
     Ref(RefKind, Box<Ty>),
     Param(ParamTy),
+    Tuple(Vec<Ty>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Layout {
     Bool,
     Int(IntTy),
@@ -74,6 +75,7 @@ pub enum Layout {
     Adt(DefId),
     Ref,
     Param,
+    Tuple(Vec<Layout>),
 }
 
 pub struct Indices {
@@ -275,6 +277,7 @@ impl fmt::Debug for Ty {
             Ty::Ref(RefKind::Mut, ty) => write!(f, "&mut {ty:?}"),
             Ty::Ref(RefKind::Shr, ty) => write!(f, "&{ty:?}"),
             Ty::Param(param) => write!(f, "{param}"),
+            Ty::Tuple(tys) => write!(f, "({:?})", tys.iter().format(", ")),
         }
     }
 }

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -328,6 +328,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
             rustc_middle::ty::TyKind::Adt(adt_def, _) => Ok(Layout::Adt(adt_def.did)),
             rustc_middle::ty::TyKind::Ref(..) => Ok(Layout::Ref),
             rustc_middle::ty::TyKind::Float(float_ty) => Ok(Layout::Float(*float_ty)),
+            rustc_middle::ty::TyKind::Tuple(tys) if tys.is_empty() => Ok(Layout::Tuple(vec![])),
             _ => self.emit_err(None, format!("unsupported type `{ty:?}`, kind: `{:?}`", ty.kind())),
         }
     }
@@ -356,6 +357,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
                 let adt = core::BaseTy::Adt(adt_def.did, substs);
                 Ok(core::Ty::Exists(adt, core::Pred::Hole))
             }
+            rustc_middle::ty::TyKind::Tuple(tys) if tys.is_empty() => Ok(core::Ty::Tuple(vec![])),
             _ => self.emit_err(None, format!("unsupported type `{ty:?}`, kind: `{:?}`", ty.kind())),
         }
     }

--- a/liquid-rust-syntax/src/resolve.rs
+++ b/liquid-rust-syntax/src/resolve.rs
@@ -129,6 +129,7 @@ impl<'tcx> Resolver<'tcx> {
                 let ty = self.resolve_ty(*ty)?;
                 surface::TyKind::Ref(rk, Box::new(ty))
             }
+            surface::TyKind::Unit => surface::TyKind::Unit,
         };
         Ok(surface::Ty { kind, span: ty.span })
     }

--- a/liquid-rust-syntax/src/surface.rs
+++ b/liquid-rust-syntax/src/surface.rs
@@ -625,6 +625,7 @@ pub mod zip {
             (TyKind::Ref(rk, ty), TyKind::Ref(default_rk, default)) if rk == *default_rk => {
                 TyKind::Ref(rk, Box::new(zip_ty(*ty, default)))
             }
+            (TyKind::Unit, TyKind::Unit) => TyKind::Unit,
             _ => panic!("incompatible types `{default:?}`"),
         };
         Ty { kind, span: ty.span }

--- a/liquid-rust-syntax/src/surface.rs
+++ b/liquid-rust-syntax/src/surface.rs
@@ -99,6 +99,9 @@ pub enum TyKind<T = Ident> {
 
     /// Strong reference, &strg<self: i32>
     StrgRef(Ident, Box<Ty<T>>),
+
+    /// ()
+    Unit,
 }
 
 #[derive(Debug, Clone)]
@@ -258,6 +261,7 @@ pub fn default_ty(ty: rustc_middle::ty::Ty) -> Ty<Res> {
             let tgt_ty = default_ty(*ty);
             TyKind::Ref(ref_kind, Box::new(tgt_ty))
         }
+        rustc_middle::ty::TyKind::Tuple(tys) if tys.is_empty() => TyKind::Unit,
         _ => TyKind::Path(default_path(ty)),
     };
     Ty { kind, span: rustc_span::DUMMY_SP }
@@ -419,6 +423,7 @@ pub mod expand {
             }
             TyKind::Ref(rk, t) => TyKind::Ref(*rk, Box::new(expand_ty(aliases, &*t))),
             TyKind::StrgRef(rk, t) => TyKind::StrgRef(*rk, Box::new(expand_ty(aliases, &*t))),
+            TyKind::Unit => TyKind::Unit,
         }
     }
 
@@ -527,6 +532,7 @@ pub mod expand {
             }
             TyKind::Ref(rk, t) => TyKind::Ref(*rk, Box::new(subst_ty(subst, &*t))),
             TyKind::StrgRef(rk, t) => TyKind::StrgRef(*rk, Box::new(subst_ty(subst, &*t))),
+            TyKind::Unit => TyKind::Unit,
         }
     }
 }

--- a/liquid-rust-syntax/src/surface_grammar.lalrpop
+++ b/liquid-rust-syntax/src/surface_grammar.lalrpop
@@ -93,6 +93,8 @@ TyKind: surface::TyKind = {
     <path:Path>                                        => surface::TyKind::Path(<>),
     <path:Path> "{" <bind:Ident> ":" <pred:Level1> "}" => surface::TyKind::Exists { <> },
     <path:Path> "[" <indices:Indices> "]"              => surface::TyKind::Indexed { <> },
+
+    "(" ")"  => surface::TyKind::Unit
 }
 
 GenericArgs: Vec<surface::Ty> = {

--- a/liquid-rust-tests/tests/lib/surface/rvec.rs
+++ b/liquid-rust-tests/tests/lib/surface/rvec.rs
@@ -15,12 +15,11 @@ impl<T> RVec<T> {
 
     #[lr::assume]
     #[lr::sig(
-    fn(self: &strg RVec<T>[@n], T) -> i32[0]
+    fn(self: &strg RVec<T>[@n], T) -> ()
     ensures self: RVec<T>[n+1]
     )]
-    pub fn push(&mut self, item: T) -> i32 {
+    pub fn push(&mut self, item: T) {
         self.inner.push(item);
-        0
     }
 
     #[lr::assume]
@@ -58,10 +57,9 @@ impl<T> RVec<T> {
     }
 
     #[lr::assume]
-    #[lr::sig(fn(&mut RVec<T>[@n], a: usize{0 <= a && a < n}, b: usize{0 <= b && b < n}) -> i32[0])]
-    pub fn swap(&mut self, a: usize, b: usize) -> i32 {
+    #[lr::sig(fn(&mut RVec<T>[@n], a: usize{0 <= a && a < n}, b: usize{0 <= b && b < n}) -> ())]
+    pub fn swap(&mut self, a: usize, b: usize) {
         self.inner.swap(a, b);
-        0
     }
 
     #[lr::assume]

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -134,6 +134,10 @@ impl LoweringCtxt {
             core::Ty::Ref(rk, ty) => ty::Ty::mk_ref(Self::lower_ref_kind(*rk), self.lower_ty(ty)),
             core::Ty::Param(param) => ty::Ty::param(*param),
             core::Ty::Float(float_ty) => ty::Ty::float(*float_ty),
+            core::Ty::Tuple(tys) => {
+                let tys = tys.iter().map(|ty| self.lower_ty(ty)).collect_vec();
+                ty::Ty::tuple(tys)
+            }
         }
     }
 
@@ -177,6 +181,21 @@ impl LoweringCtxt {
         match lit {
             core::Lit::Int(n) => ty::Constant::from(n),
             core::Lit::Bool(b) => ty::Constant::from(b),
+        }
+    }
+}
+
+pub fn lower_layout(layout: &core::Layout) -> ty::Layout {
+    match layout {
+        core::Layout::Bool => ty::Layout::bool(),
+        core::Layout::Int(int_ty) => ty::Layout::int(*int_ty),
+        core::Layout::Uint(uint_ty) => ty::Layout::uint(*uint_ty),
+        core::Layout::Float(float_ty) => ty::Layout::float(*float_ty),
+        core::Layout::Adt(def_id) => ty::Layout::adt(*def_id),
+        core::Layout::Ref => ty::Layout::mk_ref(),
+        core::Layout::Param => ty::Layout::param(),
+        core::Layout::Tuple(layouts) => {
+            ty::Layout::tuple(layouts.iter().map(|l| lower_layout(l)).collect_vec())
         }
     }
 }

--- a/liquid-rust-typeck/src/type_env.rs
+++ b/liquid-rust-typeck/src/type_env.rs
@@ -11,13 +11,13 @@ use crate::{
 };
 use itertools::{izip, Itertools};
 use liquid_rust_common::index::IndexGen;
-use liquid_rust_core::{ir, ty::Layout};
+use liquid_rust_core::ir;
 use rustc_hash::{FxHashMap, FxHashSet};
 use rustc_middle::ty::TyCtxt;
 
 use self::paths_tree::{LookupResult, PathsTree};
 
-use super::ty::{Loc, Name, Pred, Sort};
+use super::ty::{Layout, Loc, Name, Pred, Sort};
 
 #[derive(Clone, Default)]
 pub struct TypeEnv {
@@ -49,8 +49,10 @@ impl TypeEnv {
     }
 
     pub fn alloc(&mut self, loc: impl Into<Loc>, layout: Layout) {
+        // TODO(nilehmann) we should probably do this for all ZSTs
+        let ty = if layout.is_unit() { Ty::tuple(vec![]) } else { Ty::uninit(layout) };
         let loc = loc.into();
-        self.bindings.insert(loc, Ty::uninit(layout));
+        self.bindings.insert(loc, ty);
     }
 
     pub fn into_infer(self, genv: &GlobalEnv, scope: Scope) -> TypeEnvInfer {
@@ -195,7 +197,7 @@ impl TypeEnv {
         subst: &mut Subst,
     ) {
         match (ty1.kind(), ty2.kind()) {
-            (TyKind::Refine(_, exprs1), TyKind::Refine(_, exprs2)) => {
+            (TyKind::Indexed(_, exprs1), TyKind::Indexed(_, exprs2)) => {
                 for (e1, e2) in iter::zip(exprs1, exprs2) {
                     subst.infer_from_exprs(params, e1, e2);
                 }
@@ -343,7 +345,7 @@ impl TypeEnvInfer {
         ty: &Ty,
     ) -> Ty {
         match ty.kind() {
-            TyKind::Refine(bty, exprs) => {
+            TyKind::Indexed(bty, exprs) => {
                 let sorts = genv.sorts(bty);
                 let exprs = exprs
                     .iter()
@@ -361,6 +363,13 @@ impl TypeEnvInfer {
                     .collect_vec();
                 let bty = TypeEnvInfer::pack_bty(params, genv, scope, name_gen, bty);
                 Ty::refine(bty, exprs)
+            }
+            TyKind::Tuple(tys) => {
+                let tys = tys
+                    .iter()
+                    .map(|ty| TypeEnvInfer::pack_ty(params, genv, scope, name_gen, ty))
+                    .collect_vec();
+                Ty::tuple(tys)
             }
             // TODO(nilehmann) [`TyKind::Exists`] could also in theory contains free variables.
             TyKind::Exists(_, _)
@@ -474,17 +483,17 @@ impl TypeEnvInfer {
         match (ty1.kind(), ty2.kind()) {
             (TyKind::Uninit(layout), _) => {
                 debug_assert_eq!(layout, &ty2.layout());
-                Ty::uninit(*layout)
+                Ty::uninit(layout.clone())
             }
             (_, TyKind::Uninit(layout)) => {
                 debug_assert_eq!(layout, &ty1.layout());
-                Ty::uninit(*layout)
+                Ty::uninit(layout.clone())
             }
             (TyKind::Ptr(path1), TyKind::Ptr(path2)) => {
                 debug_assert_eq!(path1, path2);
                 Ty::strg_ref(path1.clone())
             }
-            (TyKind::Refine(bty1, exprs1), TyKind::Refine(bty2, exprs2)) => {
+            (TyKind::Indexed(bty1, exprs1), TyKind::Indexed(bty2, exprs2)) => {
                 let bty = self.join_bty(genv, bty1, bty2);
                 let exprs = izip!(exprs1, exprs2, genv.sorts(&bty))
                     .map(|(e1, e2, sort)| {
@@ -498,8 +507,8 @@ impl TypeEnvInfer {
                     .collect_vec();
                 Ty::refine(bty, exprs)
             }
-            (TyKind::Exists(bty1, _), TyKind::Refine(bty2, ..) | TyKind::Exists(bty2, ..))
-            | (TyKind::Refine(bty1, _), TyKind::Exists(bty2, ..)) => {
+            (TyKind::Exists(bty1, _), TyKind::Indexed(bty2, ..) | TyKind::Exists(bty2, ..))
+            | (TyKind::Indexed(bty1, _), TyKind::Exists(bty2, ..)) => {
                 let bty = self.join_bty(genv, bty1, bty2);
                 Ty::exists(bty, Pred::Hole)
             }

--- a/liquid-rust-typeck/src/type_env.rs
+++ b/liquid-rust-typeck/src/type_env.rs
@@ -524,6 +524,13 @@ impl TypeEnvInfer {
                 debug_assert_eq!(param_ty1, param_ty2);
                 Ty::param(*param_ty1)
             }
+            (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
+                assert!(
+                    tys1.is_empty() && tys2.is_empty(),
+                    "join of non-empty tuples is not supported yet"
+                );
+                Ty::tuple(vec![])
+            }
             _ => todo!("`{ty1:?}` -- `{ty2:?}`"),
         }
     }

--- a/liquid-rust-typeck/src/type_env/paths_tree.rs
+++ b/liquid-rust-typeck/src/type_env/paths_tree.rs
@@ -398,7 +398,7 @@ fn ty_infer_folding(
     ty2: &Ty,
 ) {
     match (ty1.kind(), ty2.kind()) {
-        (TyKind::Refine(bty1, exprs1), TyKind::Refine(bty2, exprs2)) => {
+        (TyKind::Indexed(bty1, exprs1), TyKind::Indexed(bty2, exprs2)) => {
             bty_infer_folding(genv, pcx, params, bty1, bty2);
             for (e1, e2) in iter::zip(exprs1, exprs2) {
                 expr_infer_folding(params, e1, e2);

--- a/liquid-rust-typeck/src/wf.rs
+++ b/liquid-rust-typeck/src/wf.rs
@@ -126,6 +126,10 @@ impl<T: AdtSortsMap> Wf<'_, T> {
             core::Ty::Ptr(loc) => self.check_loc(env, *loc),
             core::Ty::Ref(_, ty) => self.check_type(env, ty),
             core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
+            core::Ty::Tuple(tys) => {
+                tys.iter()
+                    .try_for_each_exhaust(|ty| self.check_type(env, ty))
+            }
         }
     }
 


### PR DESCRIPTION
This is in preparation to use mir after analysis instead of the optimized version. Unit is represented as a nullary tuple as in rustc, but full support for tuples is not implemented yet.