### PR TITLE
Use mir with borrowck facts

### DIFF
--- a/liquid-rust-core/src/ir.rs
+++ b/liquid-rust-core/src/ir.rs
@@ -133,6 +133,7 @@ pub enum Constant {
     Uint(u128, UintTy),
     Float(u128, FloatTy),
     Bool(bool),
+    Unit,
 }
 
 pub enum FakeReadCause {
@@ -340,10 +341,11 @@ impl fmt::Debug for Operand {
 impl fmt::Debug for Constant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Int(n, int_ty) => write!(f, "{}{}", n, int_ty.name_str()),
-            Self::Uint(n, uint_ty) => write!(f, "{}{}", n, uint_ty.name_str()),
-            Self::Float(bits, float_ty) => write!(f, "{}{}", bits, float_ty.name_str()),
-            Self::Bool(b) => write!(f, "{}", b),
+            Constant::Int(n, int_ty) => write!(f, "{}{}", n, int_ty.name_str()),
+            Constant::Uint(n, uint_ty) => write!(f, "{}{}", n, uint_ty.name_str()),
+            Constant::Float(bits, float_ty) => write!(f, "{}{}", bits, float_ty.name_str()),
+            Constant::Bool(b) => write!(f, "{}", b),
+            Constant::Unit => write!(f, "()"),
         }
     }
 }

--- a/liquid-rust-core/src/ir.rs
+++ b/liquid-rust-core/src/ir.rs
@@ -16,9 +16,8 @@ use crate::ty::{Layout, Ty, VariantIdx};
 
 pub struct Body<'tcx> {
     pub basic_blocks: IndexVec<BasicBlock, BasicBlockData>,
-    pub arg_count: usize,
     pub local_decls: IndexVec<Local, LocalDecl>,
-    pub mir: &'tcx mir::Body<'tcx>,
+    pub mir: mir::Body<'tcx>,
 }
 
 #[derive(Debug)]
@@ -129,17 +128,17 @@ pub enum Constant {
 impl Body<'_> {
     #[inline]
     pub fn args_iter(&self) -> impl ExactSizeIterator<Item = Local> {
-        (1..self.arg_count + 1).map(Local::new)
+        (1..self.mir.arg_count + 1).map(Local::new)
     }
 
     #[inline]
     pub fn vars_and_temps_iter(&self) -> impl ExactSizeIterator<Item = Local> {
-        (self.arg_count + 1..self.local_decls.len()).map(Local::new)
+        (self.mir.arg_count + 1..self.local_decls.len()).map(Local::new)
     }
 
     #[inline]
     pub fn reverse_postorder(&self) -> impl ExactSizeIterator<Item = BasicBlock> + '_ {
-        mir::traversal::reverse_postorder(self.mir).map(|(bb, _)| bb)
+        mir::traversal::reverse_postorder(&self.mir).map(|(bb, _)| bb)
     }
 
     #[inline]

--- a/liquid-rust-core/src/ir.rs
+++ b/liquid-rust-core/src/ir.rs
@@ -71,6 +71,7 @@ pub enum TerminatorKind {
         real_target: BasicBlock,
         unwind: Option<BasicBlock>,
     },
+    Resume,
 }
 
 pub struct Statement {
@@ -284,6 +285,7 @@ impl fmt::Debug for Terminator {
             TerminatorKind::FalseUnwind { real_target, unwind } => {
                 write!(f, "falseUnwind -> [real: {real_target:?}, cleanup: {unwind:?}]")
             }
+            TerminatorKind::Resume => write!(f, "resume"),
         }
     }
 }

--- a/liquid-rust-core/src/ty.rs
+++ b/liquid-rust-core/src/ty.rs
@@ -64,6 +64,7 @@ pub enum Ty {
     Ref(RefKind, Box<Ty>),
     Param(ParamTy),
     Tuple(Vec<Ty>),
+    Never,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -76,6 +77,7 @@ pub enum Layout {
     Ref,
     Param,
     Tuple(Vec<Layout>),
+    Never,
 }
 
 pub struct Indices {
@@ -278,6 +280,7 @@ impl fmt::Debug for Ty {
             Ty::Ref(RefKind::Shr, ty) => write!(f, "&{ty:?}"),
             Ty::Param(param) => write!(f, "{param}"),
             Ty::Tuple(tys) => write!(f, "({:?})", tys.iter().format(", ")),
+            Ty::Never => write!(f, "!"),
         }
     }
 }

--- a/liquid-rust-driver/src/callbacks.rs
+++ b/liquid-rust-driver/src/callbacks.rs
@@ -159,16 +159,16 @@ impl<'tcx> CrateChecker<'tcx> {
             return Ok(());
         }
         let mir = unsafe { mir_storage::retrieve_mir_body(self.genv.tcx, def_id).body };
-        {
-            let mut w = std::io::BufWriter::new(std::io::stdout());
-            rustc_middle::mir::pretty::write_mir_fn(
-                self.genv.tcx,
-                &mir,
-                &mut |_, _| Ok(()),
-                &mut w,
-            )
-            .unwrap();
-        }
+        // {
+        //     let mut w = std::io::BufWriter::new(std::io::stdout());
+        //     rustc_middle::mir::pretty::write_mir_fn(
+        //         self.genv.tcx,
+        //         &mir,
+        //         &mut |_, _| Ok(()),
+        //         &mut w,
+        //     )
+        //     .unwrap();
+        // }
 
         let body = LoweringCtxt::lower(self.genv.tcx, mir)?;
         typeck::check(&self.genv, def_id.to_def_id(), &body, &self.qualifiers)

--- a/liquid-rust-driver/src/lib.rs
+++ b/liquid-rust-driver/src/lib.rs
@@ -37,8 +37,6 @@ pub fn run_compiler(mut args: Vec<String>) -> i32 {
     args.push(sysroot().expect("Liquid Rust requires rustup to be built."));
     // Add release mode to the arguments.
     args.push("-O".into());
-    // We don't support unwinding.
-    args.push("-Cpanic=abort".into());
     // Run the rust compiler with the arguments.
     let mut callbacks = LiquidCallbacks::default();
     catch_with_exit_code(move || RunCompiler::new(&args, &mut callbacks).run())

--- a/liquid-rust-driver/src/lib.rs
+++ b/liquid-rust-driver/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate rustc_ast;
 extern crate rustc_ast_pretty;
+extern crate rustc_borrowck;
 extern crate rustc_const_eval;
 extern crate rustc_driver;
 extern crate rustc_errors;
@@ -16,6 +17,7 @@ extern crate rustc_span;
 mod callbacks;
 mod collector;
 mod lowering;
+mod mir_storage;
 
 use callbacks::LiquidCallbacks;
 use rustc_driver::{catch_with_exit_code, RunCompiler};

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -184,8 +184,8 @@ impl<'tcx> LoweringCtxt<'tcx> {
             mir::TerminatorKind::FalseUnwind { real_target, unwind } => {
                 TerminatorKind::FalseUnwind { real_target: *real_target, unwind: *unwind }
             }
-            mir::TerminatorKind::Resume
-            | mir::TerminatorKind::Abort
+            mir::TerminatorKind::Resume => TerminatorKind::Resume,
+            mir::TerminatorKind::Abort
             | mir::TerminatorKind::Unreachable
             | mir::TerminatorKind::DropAndReplace { .. }
             | mir::TerminatorKind::Yield { .. }

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -131,7 +131,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
     ) -> Result<Terminator, ErrorReported> {
         let kind = match &terminator.kind {
             mir::TerminatorKind::Return => TerminatorKind::Return,
-            mir::TerminatorKind::Call { func, args, destination, .. } => {
+            mir::TerminatorKind::Call { func, args, destination, cleanup, .. } => {
                 let (func, substs) = match func.ty(&self.body, self.tcx).kind() {
                     rustc_middle::ty::TyKind::FnDef(fn_def, substs) => {
                         let substs = substs
@@ -161,6 +161,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
                         .iter()
                         .map(|arg| self.lower_operand(arg))
                         .try_collect()?,
+                    cleanup: *cleanup,
                 }
             }
             mir::TerminatorKind::SwitchInt { discr, targets, .. } => {

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -311,6 +311,7 @@ impl<'tcx> LoweringCtxt<'tcx> {
                         TyKind::Bool => {
                             Ok(Constant::Bool(scalar_to_bits(tcx, scalar, ty).unwrap() != 0))
                         }
+                        TyKind::Tuple(tys) if tys.is_empty() => Ok(Constant::Unit),
                         _ => {
                             self.emit_err(Some(span), format!("constant not supported: `{lit:?}`"))
                         }

--- a/liquid-rust-driver/src/lowering.rs
+++ b/liquid-rust-driver/src/lowering.rs
@@ -323,6 +323,9 @@ impl<'tcx> LoweringCtxt<'tcx> {
         let span = c.span;
         match lit {
             mir::ConstantKind::Ty(c) => {
+                // HACK(nilehmann) we evaluate the constant to support u32::MAX
+                // we should instead lower it as is and refine its type.
+                let c = c.eval(tcx, ParamEnv::empty());
                 if let ConstKind::Value(ConstValue::Scalar(scalar)) = c.val() {
                     let ty = c.ty();
                     match ty.kind() {

--- a/liquid-rust-driver/src/mir_storage.rs
+++ b/liquid-rust-driver/src/mir_storage.rs
@@ -30,8 +30,7 @@ pub unsafe fn store_mir_body<'tcx>(
     body_with_facts: BodyWithBorrowckFacts<'tcx>,
 ) {
     // SAFETY: See the module level comment.
-    let body_with_facts: BodyWithBorrowckFacts<'static> =
-        unsafe { std::mem::transmute(body_with_facts) };
+    let body_with_facts: BodyWithBorrowckFacts<'static> = std::mem::transmute(body_with_facts);
     SHARED_STATE.with(|state| {
         let mut map = state.borrow_mut();
         assert!(map.insert(def_id, body_with_facts).is_none());
@@ -51,5 +50,5 @@ pub(super) unsafe fn retrieve_mir_body<'tcx>(
         map.remove(&def_id).unwrap()
     });
     // SAFETY: See the module level comment.
-    unsafe { std::mem::transmute(body_with_facts) }
+    std::mem::transmute(body_with_facts)
 }

--- a/liquid-rust-driver/src/mir_storage.rs
+++ b/liquid-rust-driver/src/mir_storage.rs
@@ -1,0 +1,55 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! This module allows storing mir bodies with borrowck facts in a thread-local
+//! storage. Unfortunately, thread local storage requires all data stored in it
+//! to have a `'static` lifetime. Therefore, we transmute the lifetime `'tcx`
+//! away when storing the data. To ensure that nothing gets meessed up, we
+//! require the client to provide a witness: an instance of type `TyCtxt<'tcx>`
+//! that is used to show that the lifetime that the client provided is indeed
+//! `'tcx`.
+
+use rustc_borrowck::BodyWithBorrowckFacts;
+use rustc_hir::def_id::LocalDefId;
+use rustc_middle::ty::TyCtxt;
+use std::{cell::RefCell, collections::HashMap, thread_local};
+
+thread_local! {
+    pub static SHARED_STATE:
+        RefCell<HashMap<LocalDefId, BodyWithBorrowckFacts<'static>>> =
+        RefCell::new(HashMap::new());
+}
+
+/// # Safety
+///
+/// See the module level comment.
+pub unsafe fn store_mir_body<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+    body_with_facts: BodyWithBorrowckFacts<'tcx>,
+) {
+    // SAFETY: See the module level comment.
+    let body_with_facts: BodyWithBorrowckFacts<'static> =
+        unsafe { std::mem::transmute(body_with_facts) };
+    SHARED_STATE.with(|state| {
+        let mut map = state.borrow_mut();
+        assert!(map.insert(def_id, body_with_facts).is_none());
+    });
+}
+
+/// # Safety
+///
+/// See the module level comment.
+#[allow(clippy::needless_lifetimes)] // We want to be very explicit about lifetimes here.
+pub(super) unsafe fn retrieve_mir_body<'tcx>(
+    _tcx: TyCtxt<'tcx>,
+    def_id: LocalDefId,
+) -> BodyWithBorrowckFacts<'tcx> {
+    let body_with_facts: BodyWithBorrowckFacts<'static> = SHARED_STATE.with(|state| {
+        let mut map = state.borrow_mut();
+        map.remove(&def_id).unwrap()
+    });
+    // SAFETY: See the module level comment.
+    unsafe { std::mem::transmute(body_with_facts) }
+}

--- a/liquid-rust-typeck/src/checker.rs
+++ b/liquid-rust-typeck/src/checker.rs
@@ -770,6 +770,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
                 Ty::refine(BaseTy::Bool, vec![e])
             }
             Constant::Float(_, float_ty) => Ty::float(*float_ty),
+            Constant::Unit => Ty::unit(),
         }
     }
 

--- a/liquid-rust-typeck/src/checker.rs
+++ b/liquid-rust-typeck/src/checker.rs
@@ -308,6 +308,7 @@ impl<'a, 'tcx, M: Mode> Checker<'a, 'tcx, M> {
             TerminatorKind::FalseUnwind { real_target, unwind } => {
                 Ok(vec![(*real_target, None), (unwind.unwrap(), None)])
             }
+            TerminatorKind::Resume => todo!("implement checking of cleanup code"),
         }
     }
 

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -66,7 +66,7 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
             }
             (TyKind::Exists(bty, p), _) => {
                 let exprs = ck.pcx.push_bindings(&ck.genv.sorts(bty), p);
-                let ty1 = Ty::refine(bty.clone(), exprs);
+                let ty1 = Ty::indexed(bty.clone(), exprs);
                 ck.subtyping(&ty1, ty2);
                 return;
             }

--- a/liquid-rust-typeck/src/global_env.rs
+++ b/liquid-rust-typeck/src/global_env.rs
@@ -112,7 +112,7 @@ impl<'tcx> GlobalEnv<'tcx> {
             .collect_vec();
         let ret = ty::Ty::indexed(bty, exprs);
         let sig = ty::FnSig::new(vec![], args, ret, vec![]);
-        ty::Binders::new(&adt_def.refined_by()[..], sig)
+        ty::Binders::new(adt_def.refined_by(), sig)
     }
 }
 

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -196,7 +196,7 @@ pub fn lower_layout(layout: &core::Layout) -> ty::Layout {
         core::Layout::Ref => ty::Layout::mk_ref(),
         core::Layout::Param => ty::Layout::param(),
         core::Layout::Tuple(layouts) => {
-            ty::Layout::tuple(layouts.iter().map(|l| lower_layout(l)).collect_vec())
+            ty::Layout::tuple(layouts.iter().map(lower_layout).collect_vec())
         }
         core::Layout::Never => ty::Layout::never(),
     }

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -120,7 +120,7 @@ impl LoweringCtxt {
                     .iter()
                     .map(|e| self.lower_expr(e))
                     .collect_vec();
-                ty::Ty::refine(self.lower_base_ty(bty), exprs)
+                ty::Ty::indexed(self.lower_base_ty(bty), exprs)
             }
             core::Ty::Exists(bty, pred) => {
                 let bty = self.lower_base_ty(bty);
@@ -138,6 +138,7 @@ impl LoweringCtxt {
                 let tys = tys.iter().map(|ty| self.lower_ty(ty)).collect_vec();
                 ty::Ty::tuple(tys)
             }
+            core::Ty::Never => ty::Ty::never(),
         }
     }
 
@@ -197,6 +198,7 @@ pub fn lower_layout(layout: &core::Layout) -> ty::Layout {
         core::Layout::Tuple(layouts) => {
             ty::Layout::tuple(layouts.iter().map(|l| lower_layout(l)).collect_vec())
         }
+        core::Layout::Never => ty::Layout::never(),
     }
 }
 

--- a/liquid-rust-typeck/src/subst.rs
+++ b/liquid-rust-typeck/src/subst.rs
@@ -86,7 +86,7 @@ impl Subst<'_> {
     pub fn subst_ty(&self, ty: &Ty) -> Ty {
         match ty.kind() {
             TyKind::Indexed(bty, exprs) => {
-                Ty::refine(
+                Ty::indexed(
                     self.subst_base_ty(bty),
                     exprs.iter().map(|e| self.subst_expr(e)).collect_vec(),
                 )
@@ -101,6 +101,7 @@ impl Subst<'_> {
                 let tys = tys.iter().map(|ty| self.subst_ty(ty)).collect_vec();
                 Ty::tuple(tys)
             }
+            TyKind::Never => Ty::never(),
         }
     }
 

--- a/liquid-rust-typeck/src/ty.rs
+++ b/liquid-rust-typeck/src/ty.rs
@@ -331,6 +331,10 @@ impl Ty {
         TyKind::Param(param).intern()
     }
 
+    pub fn unit() -> Ty {
+        Ty::tuple(vec![])
+    }
+
     pub fn fill_holes(&self, mk_pred: &mut impl FnMut(&BaseTy) -> Pred) -> Ty {
         match self.kind() {
             TyKind::Indexed(bty, exprs) => Ty::refine(bty.fill_holes(mk_pred), exprs.clone()),

--- a/liquid-rust-typeck/src/ty.rs
+++ b/liquid-rust-typeck/src/ty.rs
@@ -86,6 +86,7 @@ pub enum TyKind {
     Ptr(Path),
     Ref(RefKind, Ty),
     Param(ParamTy),
+    Never,
 }
 
 pub type Layout = Interned<LayoutS>;
@@ -105,6 +106,7 @@ pub enum LayoutKind {
     Ref,
     Param,
     Tuple(List<Layout>),
+    Never,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Debug)]
@@ -312,7 +314,7 @@ impl Ty {
         TyKind::Uninit(layout).intern()
     }
 
-    pub fn refine<T>(bty: BaseTy, exprs: T) -> Ty
+    pub fn indexed<T>(bty: BaseTy, exprs: T) -> Ty
     where
         List<Expr>: From<T>,
     {
@@ -335,9 +337,13 @@ impl Ty {
         Ty::tuple(vec![])
     }
 
+    pub fn never() -> Ty {
+        TyKind::Never.intern()
+    }
+
     pub fn fill_holes(&self, mk_pred: &mut impl FnMut(&BaseTy) -> Pred) -> Ty {
         match self.kind() {
-            TyKind::Indexed(bty, exprs) => Ty::refine(bty.fill_holes(mk_pred), exprs.clone()),
+            TyKind::Indexed(bty, exprs) => Ty::indexed(bty.fill_holes(mk_pred), exprs.clone()),
             TyKind::Exists(bty, p) => {
                 let p = if let Pred::Hole = p { mk_pred(bty) } else { p.clone() };
                 let bty = bty.fill_holes(mk_pred);
@@ -351,6 +357,7 @@ impl Ty {
                 let tys = tys.iter().map(|ty| ty.fill_holes(mk_pred)).collect_vec();
                 Ty::tuple(tys)
             }
+            TyKind::Never => Ty::never(),
         }
     }
 
@@ -368,6 +375,7 @@ impl Ty {
                 let tys = tys.iter().map(|ty| ty.with_holes()).collect_vec();
                 Ty::tuple(tys)
             }
+            TyKind::Never => Ty::never(),
         }
     }
 }
@@ -405,6 +413,7 @@ impl TyS {
                 let layouts = tys.iter().map(|ty| ty.layout()).collect_vec();
                 Layout::tuple(layouts)
             }
+            TyKind::Never => Layout::never(),
         }
     }
 
@@ -464,6 +473,10 @@ impl Layout {
 
     pub fn bool() -> Layout {
         LayoutKind::Bool.intern()
+    }
+
+    pub fn never() -> Layout {
+        LayoutKind::Never.intern()
     }
 }
 
@@ -969,6 +982,7 @@ mod pretty {
                 TyKind::Ref(RefKind::Shr, ty) => w!("&{:?}", ty),
                 TyKind::Param(param) => w!("{}", ^param),
                 TyKind::Tuple(tys) => w!("({:?})", join!(", ", tys)),
+                TyKind::Never => w!("!"),
             }
         }
 

--- a/liquid-rust-typeck/src/type_env.rs
+++ b/liquid-rust-typeck/src/type_env.rs
@@ -298,7 +298,7 @@ impl TypeEnv {
 impl TypeEnvInfer {
     pub fn enter(&self, pcx: &mut PureCtxt) -> TypeEnv {
         let mut subst = Subst::empty();
-        // HACK(nilehmann) it is crucial that the order in this iteration is the same than
+        // HACK(nilehmann) it is crucial that the order in this iteration is the same as
         // [`TypeEnvInfer::into_bb_env`] otherwise names will be out of order in the checking phase.
         for (name, sort) in self.params.iter() {
             let e = pcx.push_binding(sort.clone(), &Pred::tt());
@@ -563,7 +563,7 @@ impl TypeEnvInfer {
     ) -> BasicBlockEnv {
         let mut params = vec![];
         let mut constrs = vec![];
-        // HACK(nilehmann) it is crucial that the order in this iteration is the same than
+        // HACK(nilehmann) it is crucial that the order in this iteration is the same as
         // [`TypeEnvInfer::enter`] otherwise names will be out of order in the checking phase.
         for (name, sort) in self.params {
             if sort != Sort::loc() {

--- a/liquid-rust-typeck/src/type_env/paths_tree.rs
+++ b/liquid-rust-typeck/src/type_env/paths_tree.rs
@@ -346,7 +346,7 @@ impl Node {
                 let adt_def = genv.adt_def(*did);
                 let exprs = fold(genv, pcx, &adt_def, &fields[..], *variant_idx);
                 let adt = BaseTy::adt(*did, vec![]);
-                let ty = Ty::refine(adt, exprs);
+                let ty = Ty::indexed(adt, exprs);
                 *self = Node::Ty(ty);
                 if let Node::Ty(ty) = self {
                     ty

--- a/liquid-rust-typeck/src/wf.rs
+++ b/liquid-rust-typeck/src/wf.rs
@@ -125,11 +125,11 @@ impl<T: AdtSortsMap> Wf<'_, T> {
             }
             core::Ty::Ptr(loc) => self.check_loc(env, *loc),
             core::Ty::Ref(_, ty) => self.check_type(env, ty),
-            core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
             core::Ty::Tuple(tys) => {
                 tys.iter()
                     .try_for_each_exhaust(|ty| self.check_type(env, ty))
             }
+            core::Ty::Never | core::Ty::Param(_) | core::Ty::Float(_) => Ok(()),
         }
     }
 


### PR DESCRIPTION
Use mir from [get_body_with_borrowck_facts](https://doc.rust-lang.org/nightly/nightly-rustc/rustc_borrowck/consumers/fn.get_body_with_borrowck_facts.html) in preparation to use lifetime information. This required implementing support for several additional mir constructs which weren't present in the optimized mir:

* Terminators: `FalseEdge`, `FalseUnwind`, `DropAndReplace`
* Statements: `AscribeUserType`
* Rvalue: `Aggregate`
* Constant: unit literal
* Type: `Never`

Most of them have no interaction with refinements except for `RValue::Aggregate`, which actually simplifies the construction of adts.