### PR TITLE
Store AdtDef in Basety

### DIFF
--- a/liquid-rust-core/src/ty.rs
+++ b/liquid-rust-core/src/ty.rs
@@ -17,8 +17,13 @@ pub trait AdtSortsMap {
     fn get(&self, def_id: DefId) -> Option<&[Sort]>;
 }
 
+pub struct AdtDef {
+    pub def_id: DefId,
+    pub kind: AdtDefKind,
+}
+
 #[derive(Debug)]
-pub enum AdtDef {
+pub enum AdtDefKind {
     Transparent { refined_by: Vec<Param>, variants: IndexVec<VariantIdx, VariantDef> },
     Opaque { refined_by: Vec<Param> },
 }
@@ -181,12 +186,16 @@ impl AdtDef {
             .iter()
             .map(|variant| VariantDef::default(tcx, variant))
             .collect();
-        AdtDef::Transparent { refined_by: vec![], variants }
+        let kind = AdtDefKind::Transparent { refined_by: vec![], variants };
+        let def_id = struct_def.did;
+        AdtDef { def_id, kind }
     }
 
     pub fn refined_by(&self) -> &[Param] {
-        match self {
-            Self::Transparent { refined_by, .. } | Self::Opaque { refined_by } => refined_by,
+        match &self.kind {
+            AdtDefKind::Transparent { refined_by, .. } | AdtDefKind::Opaque { refined_by } => {
+                refined_by
+            }
         }
     }
 

--- a/liquid-rust-driver/src/collector.rs
+++ b/liquid-rust-driver/src/collector.rs
@@ -125,7 +125,7 @@ impl<'tcx, 'a> SpecCollector<'tcx, 'a> {
 
         self.specs
             .structs
-            .insert(def_id, surface::StructDef { refined_by, fields, opaque });
+            .insert(def_id, surface::StructDef { def_id, refined_by, fields, opaque });
 
         Ok(())
     }

--- a/liquid-rust-syntax/src/resolve.rs
+++ b/liquid-rust-syntax/src/resolve.rs
@@ -61,15 +61,20 @@ impl<'tcx> Resolver<'tcx> {
 
     pub fn resolve_struct_def(
         &mut self,
-        spec: surface::StructDef,
+        struct_def: surface::StructDef,
     ) -> Result<surface::StructDef<Res>, ErrorReported> {
-        let fields = spec
+        let fields = struct_def
             .fields
             .into_iter()
             .map(|ty| ty.map(|ty| self.resolve_ty(ty)).transpose())
             .try_collect_exhaust()?;
 
-        Ok(surface::StructDef { refined_by: spec.refined_by, fields, opaque: spec.opaque })
+        Ok(surface::StructDef {
+            def_id: struct_def.def_id,
+            refined_by: struct_def.refined_by,
+            fields,
+            opaque: struct_def.opaque,
+        })
     }
 
     pub fn resolve_fn_sig(

--- a/liquid-rust-syntax/src/surface.rs
+++ b/liquid-rust-syntax/src/surface.rs
@@ -27,6 +27,7 @@ pub struct Alias<T = Ident> {
 
 #[derive(Debug)]
 pub struct StructDef<T = Ident> {
+    pub def_id: LocalDefId,
     pub refined_by: Option<Params>,
     pub fields: Vec<Option<Ty<T>>>,
     pub opaque: bool,

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -123,10 +123,10 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
                 debug_assert_eq!(uint_ty1, uint_ty2);
             }
             (BaseTy::Bool, BaseTy::Bool) => {}
-            (BaseTy::Adt(did1, substs1), BaseTy::Adt(did2, substs2)) => {
-                debug_assert_eq!(did1, did2);
+            (BaseTy::Adt(def1, substs1), BaseTy::Adt(def2, substs2)) => {
+                debug_assert_eq!(def1.def_id(), def2.def_id());
                 debug_assert_eq!(substs1.len(), substs2.len());
-                let variances = self.genv.variances_of(*did1);
+                let variances = self.genv.variances_of(def1.def_id());
                 for (variance, ty1, ty2) in izip!(variances, substs1.iter(), substs2.iter()) {
                     self.polymorphic_subtyping(*variance, ty1, ty2);
                 }

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -46,15 +46,15 @@ impl LoweringCtxt {
 
         let refined_by = cx.lower_params(&name_gen, adt_def.refined_by());
 
-        match adt_def {
-            core::AdtDef::Transparent { variants, .. } => {
+        match &adt_def.kind {
+            core::AdtDefKind::Transparent { variants, .. } => {
                 let variants = variants
                     .iter()
                     .map(|variant| cx.lower_variant_def(variant))
                     .collect_vec();
-                ty::AdtDef::transparent(refined_by, IndexVec::from_raw(variants))
+                ty::AdtDef::transparent(adt_def.def_id, refined_by, IndexVec::from_raw(variants))
             }
-            core::AdtDef::Opaque { .. } => ty::AdtDef::opaque(refined_by),
+            core::AdtDefKind::Opaque { .. } => ty::AdtDef::opaque(adt_def.def_id, refined_by),
         }
     }
 

--- a/liquid-rust-typeck/src/lowering.rs
+++ b/liquid-rust-typeck/src/lowering.rs
@@ -1,22 +1,28 @@
-use crate::ty::{self, Path, VariantDef};
+use crate::{
+    global_env::GlobalEnv,
+    ty::{self, Path, VariantDef},
+};
 use itertools::Itertools;
 use liquid_rust_common::index::{IndexGen, IndexVec};
 use liquid_rust_core::ty as core;
 use rustc_hash::FxHashMap;
 
-pub struct LoweringCtxt {
-    name_map: FxHashMap<core::Name, ty::Name>,
+pub struct LoweringCtxt<'a, 'tcx> {
+    genv: &'a GlobalEnv<'tcx>,
+    name_map: NameMap,
 }
 
-impl LoweringCtxt {
-    pub fn empty() -> Self {
-        Self { name_map: FxHashMap::default() }
+type NameMap = FxHashMap<core::Name, ty::Name>;
+
+impl<'a, 'tcx> LoweringCtxt<'a, 'tcx> {
+    pub fn empty(genv: &'a GlobalEnv<'tcx>) -> Self {
+        Self { genv, name_map: FxHashMap::default() }
     }
 
-    pub fn lower_fn_sig(fn_sig: core::FnSig) -> ty::Binders<ty::FnSig> {
+    pub fn lower_fn_sig(genv: &GlobalEnv, fn_sig: core::FnSig) -> ty::Binders<ty::FnSig> {
         let name_gen = IndexGen::new();
 
-        let mut cx = LoweringCtxt::empty();
+        let mut cx = LoweringCtxt::empty(genv);
 
         let params = cx.lower_params(&name_gen, &fn_sig.params);
 
@@ -40,9 +46,9 @@ impl LoweringCtxt {
         ty::Binders::new(params, ty::FnSig::new(requires, args, ret, ensures))
     }
 
-    pub fn lower_adt_def(adt_def: &core::AdtDef) -> ty::AdtDef {
+    pub fn lower_adt_def(genv: &GlobalEnv, adt_def: &core::AdtDef) -> ty::AdtDef {
         let name_gen = IndexGen::new();
-        let mut cx = LoweringCtxt::empty();
+        let mut cx = LoweringCtxt::empty(genv);
 
         let refined_by = cx.lower_params(&name_gen, adt_def.refined_by());
 
@@ -75,7 +81,7 @@ impl LoweringCtxt {
                     self.lower_ty(ty),
                 )
             }
-            core::Constr::Pred(e) => ty::Constr::Pred(self.lower_expr(e)),
+            core::Constr::Pred(e) => ty::Constr::Pred(lower_expr(e, &self.name_map)),
         }
     }
 
@@ -98,16 +104,16 @@ impl LoweringCtxt {
         let name_gen = IndexGen::new();
         let mut args = Vec::new();
 
-        let mut cx = LoweringCtxt::empty();
+        let mut name_map = NameMap::default();
 
         for param in &qualifier.args {
             let fresh = name_gen.fresh();
-            cx.name_map.insert(param.name.name, fresh);
+            name_map.insert(param.name.name, fresh);
             let sort = lower_sort(param.sort);
             args.push((fresh, sort));
         }
 
-        let expr = cx.lower_expr(&qualifier.expr);
+        let expr = lower_expr(&qualifier.expr, &name_map);
 
         ty::Qualifier { name: qualifier.name.clone(), args, expr }
     }
@@ -118,7 +124,7 @@ impl LoweringCtxt {
                 let exprs = refine
                     .exprs
                     .iter()
-                    .map(|e| self.lower_expr(e))
+                    .map(|e| lower_expr(e, &self.name_map))
                     .collect_vec();
                 ty::Ty::indexed(self.lower_base_ty(bty), exprs)
             }
@@ -126,7 +132,7 @@ impl LoweringCtxt {
                 let bty = self.lower_base_ty(bty);
                 let pred = match pred {
                     core::Pred::Hole => ty::Pred::Hole,
-                    core::Pred::Expr(e) => ty::Pred::Expr(self.lower_expr(e)),
+                    core::Pred::Expr(e) => ty::Pred::Expr(lower_expr(e, &self.name_map)),
                 };
                 ty::Ty::exists(bty, pred)
             }
@@ -155,34 +161,39 @@ impl LoweringCtxt {
             core::BaseTy::Uint(uint_ty) => ty::BaseTy::Uint(*uint_ty),
             core::BaseTy::Bool => ty::BaseTy::Bool,
             core::BaseTy::Adt(did, substs) => {
+                let adt_def = self.genv.adt_def(*did);
                 let substs = substs.iter().map(|ty| self.lower_ty(ty));
-                ty::BaseTy::adt(*did, substs)
+                ty::BaseTy::adt(adt_def, substs)
             }
         }
     }
+}
 
-    fn lower_expr(&self, expr: &core::Expr) -> ty::Expr {
-        match &expr.kind {
-            core::ExprKind::Var(var, ..) => ty::Expr::var(self.lower_var(*var)),
-            core::ExprKind::Literal(lit) => ty::Expr::constant(self.lower_lit(*lit)),
-            core::ExprKind::BinaryOp(op, e1, e2) => {
-                ty::Expr::binary_op(lower_bin_op(*op), self.lower_expr(e1), self.lower_expr(e2))
-            }
+fn lower_expr(expr: &core::Expr, name_map: &NameMap) -> ty::Expr {
+    match &expr.kind {
+        core::ExprKind::Var(var, ..) => ty::Expr::var(lower_var(*var, name_map)),
+        core::ExprKind::Literal(lit) => ty::Expr::constant(lower_lit(*lit)),
+        core::ExprKind::BinaryOp(op, e1, e2) => {
+            ty::Expr::binary_op(
+                lower_bin_op(*op),
+                lower_expr(e1, name_map),
+                lower_expr(e2, name_map),
+            )
         }
     }
+}
 
-    fn lower_var(&self, var: core::Var) -> ty::Var {
-        match var {
-            core::Var::Bound(idx) => ty::Var::Bound(idx),
-            core::Var::Free(name) => ty::Var::Free(self.name_map[&name]),
-        }
+fn lower_var(var: core::Var, name_map: &NameMap) -> ty::Var {
+    match var {
+        core::Var::Bound(idx) => ty::Var::Bound(idx),
+        core::Var::Free(name) => ty::Var::Free(name_map[&name]),
     }
+}
 
-    fn lower_lit(&self, lit: core::Lit) -> ty::Constant {
-        match lit {
-            core::Lit::Int(n) => ty::Constant::from(n),
-            core::Lit::Bool(b) => ty::Constant::from(b),
-        }
+fn lower_lit(lit: core::Lit) -> ty::Constant {
+    match lit {
+        core::Lit::Int(n) => ty::Constant::from(n),
+        core::Lit::Bool(b) => ty::Constant::from(b),
     }
 }
 

--- a/liquid-rust-typeck/src/subst.rs
+++ b/liquid-rust-typeck/src/subst.rs
@@ -147,9 +147,9 @@ impl Subst<'_> {
 
     fn subst_base_ty(&self, bty: &BaseTy) -> BaseTy {
         match bty {
-            BaseTy::Adt(did, substs) => {
+            BaseTy::Adt(adt_def, substs) => {
                 let substs = substs.iter().map(|ty| self.subst_ty(ty));
-                BaseTy::adt(*did, substs)
+                BaseTy::adt(adt_def.clone(), substs)
             }
             _ => bty.clone(),
         }

--- a/liquid-rust-typeck/src/wf.rs
+++ b/liquid-rust-typeck/src/wf.rs
@@ -85,7 +85,7 @@ impl<T: AdtSortsMap> Wf<'_, T> {
 
     pub fn check_adt_def(&self, def: &core::AdtDef) -> Result<(), ErrorReported> {
         let mut env = Env::new(def.refined_by());
-        if let core::AdtDef::Transparent { variants, .. } = def {
+        if let core::AdtDefKind::Transparent { variants, .. } = &def.kind {
             variants
                 .iter()
                 .try_for_each_exhaust(|variant| self.check_variant_def(&mut env, variant))?;


### PR DESCRIPTION
This is to remove the need to pass around `genv`