### PR TITLE
Refactoring of PureCtxt

### DIFF
--- a/liquid-rust-common/src/index.rs
+++ b/liquid-rust-common/src/index.rs
@@ -17,6 +17,12 @@ impl<I: Idx> IndexGen<I> {
         Self { count: AtomicUsize::new(0), _marker: PhantomData }
     }
 
+    pub fn skipping(skip: usize) -> Self {
+        let gen = IndexGen::new();
+        gen.skip(skip);
+        gen
+    }
+
     /// Generate a fresh index of type `I`.
     ///
     /// ```ignore

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -68,9 +68,9 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
             (TyKind::Exists(bty, p), _) => {
                 let indices = ck
                     .rcx
-                    .push_bindings(&ck.genv.sorts(bty), p)
+                    .define_params(&ck.genv.sorts(bty), p)
                     .into_iter()
-                    .map(Index::from)
+                    .map(|name| Index::from(Expr::fvar(name)))
                     .collect_vec();
                 let ty1 = Ty::indexed(bty.clone(), indices);
                 ck.subtyping(&ty1, ty2);

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -10,11 +10,11 @@ use liquid_rust_middle::{
     ty::{BaseTy, BinOp, Constr, Expr, Index, Pred, RefKind, Ty, TyKind},
 };
 
-use crate::{pure_ctxt::PureCtxt, type_env::TypeEnv};
+use crate::{refine_tree::RefineCtxt, type_env::TypeEnv};
 
 pub struct ConstraintGen<'a, 'tcx> {
     pub genv: &'a GlobalEnv<'tcx>,
-    pcx: PureCtxt<'a>,
+    rcx: RefineCtxt<'a>,
     tag: Tag,
 }
 
@@ -30,12 +30,12 @@ pub enum Tag {
 }
 
 impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
-    pub fn new(genv: &'a GlobalEnv<'tcx>, pcx: PureCtxt<'a>, tag: Tag) -> Self {
-        ConstraintGen { genv, pcx, tag }
+    pub fn new(genv: &'a GlobalEnv<'tcx>, rcx: RefineCtxt<'a>, tag: Tag) -> Self {
+        ConstraintGen { genv, rcx, tag }
     }
 
     fn breadcrumb(&mut self) -> ConstraintGen<'_, 'tcx> {
-        ConstraintGen { pcx: self.pcx.breadcrumb(), ..*self }
+        ConstraintGen { rcx: self.rcx.breadcrumb(), ..*self }
     }
 
     pub fn check_constr(&mut self, env: &mut TypeEnv, constr: &Constr) {
@@ -51,7 +51,7 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
     }
 
     pub fn check_pred(&mut self, pred: impl Into<Pred>) {
-        self.pcx.push_head(pred, self.tag);
+        self.rcx.push_head(pred, self.tag);
     }
 
     pub fn subtyping(&mut self, ty1: &Ty, ty2: &Ty) {
@@ -67,7 +67,7 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
             }
             (TyKind::Exists(bty, p), _) => {
                 let indices = ck
-                    .pcx
+                    .rcx
                     .push_bindings(&ck.genv.sorts(bty), p)
                     .into_iter()
                     .map(Index::from)

--- a/liquid-rust-typeck/src/constraint_gen.rs
+++ b/liquid-rust-typeck/src/constraint_gen.rs
@@ -10,11 +10,14 @@ use liquid_rust_middle::{
     ty::{BaseTy, BinOp, Constr, Expr, Index, Pred, RefKind, Ty, TyKind},
 };
 
-use crate::{refine_tree::RefineCtxt, type_env::TypeEnv};
+use crate::{
+    refine_tree::{ConstrBuilder, RefineCtxt},
+    type_env::TypeEnv,
+};
 
 pub struct ConstraintGen<'a, 'tcx> {
     pub genv: &'a GlobalEnv<'tcx>,
-    rcx: RefineCtxt<'a>,
+    builder: ConstrBuilder<'a>,
     tag: Tag,
 }
 
@@ -30,12 +33,8 @@ pub enum Tag {
 }
 
 impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
-    pub fn new(genv: &'a GlobalEnv<'tcx>, rcx: RefineCtxt<'a>, tag: Tag) -> Self {
-        ConstraintGen { genv, rcx, tag }
-    }
-
-    fn breadcrumb(&mut self) -> ConstraintGen<'_, 'tcx> {
-        ConstraintGen { rcx: self.rcx.breadcrumb(), ..*self }
+    pub fn new(genv: &'a GlobalEnv<'tcx>, rcx: &'a mut RefineCtxt, tag: Tag) -> Self {
+        ConstraintGen { genv, builder: rcx.check_constr(), tag }
     }
 
     pub fn check_constr(&mut self, env: &mut TypeEnv, constr: &Constr) {
@@ -51,111 +50,126 @@ impl<'a, 'tcx> ConstraintGen<'a, 'tcx> {
     }
 
     pub fn check_pred(&mut self, pred: impl Into<Pred>) {
-        self.rcx.push_head(pred, self.tag);
+        self.builder.push_head(pred, self.tag);
     }
 
     pub fn subtyping(&mut self, ty1: &Ty, ty2: &Ty) {
-        let mut ck = self.breadcrumb();
-        match (ty1.kind(), ty2.kind()) {
-            (TyKind::Indexed(bty1, e1), TyKind::Indexed(bty2, e2)) if e1 == e2 => {
-                ck.bty_subtyping(bty1, bty2);
-                return;
-            }
-            (TyKind::Exists(bty1, p1), TyKind::Exists(bty2, p2)) if p1 == p2 => {
-                ck.bty_subtyping(bty1, bty2);
-                return;
-            }
-            (TyKind::Exists(bty, p), _) => {
-                let indices = ck
-                    .rcx
-                    .define_params(&ck.genv.sorts(bty), p)
-                    .into_iter()
-                    .map(|name| Index::from(Expr::fvar(name)))
-                    .collect_vec();
-                let ty1 = Ty::indexed(bty.clone(), indices);
-                ck.subtyping(&ty1, ty2);
-                return;
-            }
-            _ => {}
-        }
+        subtyping(self.genv, &mut self.builder, ty1, ty2, self.tag)
+    }
+}
 
-        match (ty1.kind(), ty2.kind()) {
-            (TyKind::Indexed(bty1, exprs1), TyKind::Indexed(bty2, exprs2)) => {
-                ck.bty_subtyping(bty1, bty2);
-                for (e1, e2) in iter::zip(exprs1, exprs2) {
-                    ck.check_pred(Expr::binary_op(BinOp::Eq, e1.clone(), e2.clone()));
-                }
-            }
-            (TyKind::Indexed(bty1, indices), TyKind::Exists(bty2, p)) => {
-                ck.bty_subtyping(bty1, bty2);
-                let exprs = indices.iter().map(|idx| idx.expr.clone()).collect_vec();
-                ck.check_pred(p.subst_bound_vars(&exprs));
-            }
-            (TyKind::Ptr(loc1), TyKind::Ptr(loc2)) => {
-                assert_eq!(loc1, loc2);
-            }
-            (TyKind::Ref(RefKind::Mut, ty1), TyKind::Ref(RefKind::Mut, ty2)) => {
-                ck.subtyping(ty1, ty2);
-                ck.subtyping(ty2, ty1);
-            }
-            (TyKind::Ref(RefKind::Shr, ty1), TyKind::Ref(RefKind::Shr, ty2)) => {
-                ck.subtyping(ty1, ty2);
-            }
-            (_, TyKind::Uninit) => {
-                // FIXME: we should rethink in which situation this is sound.
-            }
-            (TyKind::Param(param1), TyKind::Param(param2)) => {
-                debug_assert_eq!(param1, param2);
-            }
-            (TyKind::Exists(..), _) => unreachable!("subtyping with unpacked existential"),
-            (TyKind::Float(float_ty1), TyKind::Float(float_ty2)) => {
-                debug_assert_eq!(float_ty1, float_ty2);
-            }
-            (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
-                debug_assert_eq!(tys1.len(), tys2.len());
-                for (ty1, ty2) in iter::zip(tys1, tys2) {
-                    ck.subtyping(ty1, ty2);
-                }
-            }
-            _ => todo!("`{ty1:?}` <: `{ty2:?}`"),
+pub fn subtyping(genv: &GlobalEnv, builder: &mut ConstrBuilder, ty1: &Ty, ty2: &Ty, tag: Tag) {
+    let builder = &mut builder.breadcrumb();
+    match (ty1.kind(), ty2.kind()) {
+        (TyKind::Indexed(bty1, e1), TyKind::Indexed(bty2, e2)) if e1 == e2 => {
+            bty_subtyping(genv, builder, bty1, bty2, tag);
+            return;
         }
+        (TyKind::Exists(bty1, p1), TyKind::Exists(bty2, p2)) if p1 == p2 => {
+            bty_subtyping(genv, builder, bty1, bty2, tag);
+            return;
+        }
+        (TyKind::Exists(bty, p), _) => {
+            let indices = builder
+                .push_foralls(&genv.sorts(bty), p)
+                .into_iter()
+                .map(|name| Index::from(Expr::fvar(name)))
+                .collect_vec();
+            let ty1 = Ty::indexed(bty.clone(), indices);
+            subtyping(genv, builder, &ty1, ty2, tag);
+            return;
+        }
+        _ => {}
     }
 
-    fn bty_subtyping(&mut self, bty1: &BaseTy, bty2: &BaseTy) {
-        match (bty1, bty2) {
-            (BaseTy::Int(int_ty1), BaseTy::Int(int_ty2)) => {
-                debug_assert_eq!(int_ty1, int_ty2);
+    match (ty1.kind(), ty2.kind()) {
+        (TyKind::Indexed(bty1, exprs1), TyKind::Indexed(bty2, exprs2)) => {
+            bty_subtyping(genv, builder, bty1, bty2, tag);
+            for (e1, e2) in iter::zip(exprs1, exprs2) {
+                builder.push_head(Expr::binary_op(BinOp::Eq, e1.clone(), e2.clone()), tag);
             }
-            (BaseTy::Uint(uint_ty1), BaseTy::Uint(uint_ty2)) => {
-                debug_assert_eq!(uint_ty1, uint_ty2);
-            }
-            (BaseTy::Bool, BaseTy::Bool) => {}
-            (BaseTy::Adt(def1, substs1), BaseTy::Adt(def2, substs2)) => {
-                debug_assert_eq!(def1.def_id(), def2.def_id());
-                debug_assert_eq!(substs1.len(), substs2.len());
-                let variances = self.genv.variances_of(def1.def_id());
-                for (variance, ty1, ty2) in izip!(variances, substs1.iter(), substs2.iter()) {
-                    self.polymorphic_subtyping(*variance, ty1, ty2);
-                }
-            }
-            _ => unreachable!("unexpected base types: `{:?}` `{:?}`", bty1, bty2),
         }
+        (TyKind::Indexed(bty1, indices), TyKind::Exists(bty2, p)) => {
+            bty_subtyping(genv, builder, bty1, bty2, tag);
+            let exprs = indices.iter().map(|idx| idx.expr.clone()).collect_vec();
+            builder.push_head(p.subst_bound_vars(&exprs), tag);
+        }
+        (TyKind::Ptr(loc1), TyKind::Ptr(loc2)) => {
+            assert_eq!(loc1, loc2);
+        }
+        (TyKind::Ref(RefKind::Mut, ty1), TyKind::Ref(RefKind::Mut, ty2)) => {
+            variance_subtyping(genv, builder, Variance::Invariant, ty1, ty2, tag);
+        }
+        (TyKind::Ref(RefKind::Shr, ty1), TyKind::Ref(RefKind::Shr, ty2)) => {
+            subtyping(genv, builder, ty1, ty2, tag);
+        }
+        (_, TyKind::Uninit) => {
+            // FIXME: we should rethink in which situation this is sound.
+        }
+        (TyKind::Param(param1), TyKind::Param(param2)) => {
+            debug_assert_eq!(param1, param2);
+        }
+        (TyKind::Exists(..), _) => unreachable!("subtyping with unpacked existential"),
+        (TyKind::Float(float_ty1), TyKind::Float(float_ty2)) => {
+            debug_assert_eq!(float_ty1, float_ty2);
+        }
+        (TyKind::Tuple(tys1), TyKind::Tuple(tys2)) => {
+            debug_assert_eq!(tys1.len(), tys2.len());
+            for (ty1, ty2) in iter::zip(tys1, tys2) {
+                subtyping(genv, builder, ty1, ty2, tag);
+            }
+        }
+        _ => todo!("`{ty1:?}` <: `{ty2:?}`"),
     }
+}
 
-    fn polymorphic_subtyping(&mut self, variance: Variance, ty1: &Ty, ty2: &Ty) {
-        match variance {
-            rustc_middle::ty::Variance::Covariant => {
-                self.subtyping(ty1, ty2);
-            }
-            rustc_middle::ty::Variance::Invariant => {
-                self.subtyping(ty1, ty2);
-                self.subtyping(ty2, ty1);
-            }
-            rustc_middle::ty::Variance::Contravariant => {
-                self.subtyping(ty2, ty1);
-            }
-            rustc_middle::ty::Variance::Bivariant => {}
+fn bty_subtyping(
+    genv: &GlobalEnv,
+    builder: &mut ConstrBuilder,
+    bty1: &BaseTy,
+    bty2: &BaseTy,
+    tag: Tag,
+) {
+    match (bty1, bty2) {
+        (BaseTy::Int(int_ty1), BaseTy::Int(int_ty2)) => {
+            debug_assert_eq!(int_ty1, int_ty2);
         }
+        (BaseTy::Uint(uint_ty1), BaseTy::Uint(uint_ty2)) => {
+            debug_assert_eq!(uint_ty1, uint_ty2);
+        }
+        (BaseTy::Bool, BaseTy::Bool) => {}
+        (BaseTy::Adt(def1, substs1), BaseTy::Adt(def2, substs2)) => {
+            debug_assert_eq!(def1.def_id(), def2.def_id());
+            debug_assert_eq!(substs1.len(), substs2.len());
+            let variances = genv.variances_of(def1.def_id());
+            for (variance, ty1, ty2) in izip!(variances, substs1.iter(), substs2.iter()) {
+                variance_subtyping(genv, builder, *variance, ty1, ty2, tag);
+            }
+        }
+        _ => unreachable!("unexpected base types: `{:?}` `{:?}`", bty1, bty2),
+    }
+}
+
+fn variance_subtyping(
+    genv: &GlobalEnv,
+    builder: &mut ConstrBuilder,
+    variance: Variance,
+    ty1: &Ty,
+    ty2: &Ty,
+    tag: Tag,
+) {
+    match variance {
+        rustc_middle::ty::Variance::Covariant => {
+            subtyping(genv, builder, ty1, ty2, tag);
+        }
+        rustc_middle::ty::Variance::Invariant => {
+            subtyping(genv, builder, ty1, ty2, tag);
+            subtyping(genv, builder, ty2, ty1, tag);
+        }
+        rustc_middle::ty::Variance::Contravariant => {
+            subtyping(genv, builder, ty2, ty1, tag);
+        }
+        rustc_middle::ty::Variance::Bivariant => {}
     }
 }
 

--- a/liquid-rust-typeck/src/dbg.rs
+++ b/liquid-rust-typeck/src/dbg.rs
@@ -20,32 +20,32 @@ pub use crate::_check_span as check_span;
 
 #[macro_export]
 macro_rules! _basic_block_start {
-    ($bb:expr, $pcx:expr, $env:expr) => {{
-        tracing::debug!(event = "basic_block_start", bb = ?$bb, pcx = ?$pcx, env = ?$env)
+    ($bb:expr, $rcx:expr, $env:expr) => {{
+        tracing::debug!(event = "basic_block_start", bb = ?$bb, rcx = ?$rcx, env = ?$env)
     }};
 }
 pub use crate::_basic_block_start as basic_block_start;
 
 #[macro_export]
 macro_rules! _statement{
-    ($pos:literal, $stmt:expr, $pcx:expr, $env:expr) => {{
-        tracing::debug!(event = concat!("statement_", $pos), stmt = ?$stmt, pcx = ?$pcx, env = ?$env)
+    ($pos:literal, $stmt:expr, $rcx:expr, $env:expr) => {{
+        tracing::debug!(event = concat!("statement_", $pos), stmt = ?$stmt, rcx = ?$rcx, env = ?$env)
     }};
 }
 pub use crate::_statement as statement;
 
 #[macro_export]
 macro_rules! _terminator{
-    ($pos:literal, $terminator:expr, $pcx:expr, $env:expr) => {{
-        tracing::debug!(event = concat!("terminator_", $pos), terminator = ?$terminator, pcx = ?$pcx, env = ?$env)
+    ($pos:literal, $terminator:expr, $rcx:expr, $env:expr) => {{
+        tracing::debug!(event = concat!("terminator_", $pos), terminator = ?$terminator, rcx = ?$rcx, env = ?$env)
     }};
 }
 pub use crate::_terminator as terminator;
 
 #[macro_export]
 macro_rules! _check_goto {
-    ($target:expr, $pcx:expr, $env:expr, $bb_env:expr) => {{
-        tracing::debug!(event = "check_goto", target = ?$target, pcx = ?$pcx, env = ?$env, bb_env = ?$bb_env)
+    ($target:expr, $rcx:expr, $env:expr, $bb_env:expr) => {{
+        tracing::debug!(event = "check_goto", target = ?$target, rcx = ?$rcx, env = ?$env, bb_env = ?$bb_env)
     }};
 }
 pub use crate::_check_goto as check_goto;

--- a/liquid-rust-typeck/src/param_infer.rs
+++ b/liquid-rust-typeck/src/param_infer.rs
@@ -7,7 +7,7 @@ use liquid_rust_middle::{
     ty::{subst::Subst, Constr, Expr, ExprKind, Loc, Name, Path, PolySig, Ty, TyKind},
 };
 
-use crate::{pure_ctxt::PureCtxt, type_env::TypeEnv};
+use crate::{refine_tree::RefineCtxt, type_env::TypeEnv};
 
 #[derive(Debug, Eq, PartialEq)]
 pub struct InferenceError(Name);
@@ -15,7 +15,7 @@ pub struct InferenceError(Name);
 pub fn infer_from_fn_call(
     subst: &mut Subst,
     genv: &GlobalEnv,
-    pcx: &mut PureCtxt,
+    rcx: &mut RefineCtxt,
     env: &TypeEnv,
     actuals: &[Ty],
     fn_sig: &PolySig,
@@ -37,7 +37,7 @@ pub fn infer_from_fn_call(
         .collect();
 
     for (actual, formal) in actuals.iter().zip(fn_sig.value().args().iter()) {
-        infer_from_tys(subst, genv, pcx, &params, env, actual, &requires, formal);
+        infer_from_tys(subst, genv, rcx, &params, env, actual, &requires, formal);
     }
 
     check_inference(subst, params.into_iter())
@@ -59,7 +59,7 @@ pub fn check_inference(
 fn infer_from_tys(
     subst: &mut Subst,
     genv: &GlobalEnv,
-    pcx: &mut PureCtxt,
+    rcx: &mut RefineCtxt,
     params: &FxHashSet<Name>,
     env: &TypeEnv,
     ty1: &Ty,
@@ -77,7 +77,7 @@ fn infer_from_tys(
         (TyKind::Exists(bty1, p), TyKind::Indexed(_, indices2)) => {
             // HACK(nilehmann) we should probably remove this once we have proper unpacking of &mut refs
             let sorts = genv.sorts(bty1);
-            let exprs1 = pcx.push_bindings(&sorts, p);
+            let exprs1 = rcx.push_bindings(&sorts, p);
             for (e1, idx2) in iter::zip(exprs1, indices2) {
                 if idx2.is_binder {
                     infer_from_exprs(subst, params, &e1, &idx2.expr);
@@ -85,14 +85,14 @@ fn infer_from_tys(
             }
         }
         (TyKind::Ptr(path1), TyKind::Ref(_, ty2)) => {
-            infer_from_tys(subst, genv, pcx, params, env, &env.lookup_path(path1), requires, ty2);
+            infer_from_tys(subst, genv, rcx, params, env, &env.lookup_path(path1), requires, ty2);
         }
         (TyKind::Ptr(path1), TyKind::Ptr(path2)) => {
             infer_from_paths(subst, params, path1, path2);
             infer_from_tys(
                 subst,
                 genv,
-                pcx,
+                rcx,
                 params,
                 env,
                 &env.lookup_path(path1),
@@ -102,7 +102,7 @@ fn infer_from_tys(
         }
         (TyKind::Ref(mode1, ty1), TyKind::Ref(mode2, ty2)) => {
             debug_assert_eq!(mode1, mode2);
-            infer_from_tys(subst, genv, pcx, params, env, ty1, requires, ty2);
+            infer_from_tys(subst, genv, rcx, params, env, ty1, requires, ty2);
         }
         _ => {}
     }

--- a/liquid-rust-typeck/src/param_infer.rs
+++ b/liquid-rust-typeck/src/param_infer.rs
@@ -77,10 +77,10 @@ fn infer_from_tys(
         (TyKind::Exists(bty1, p), TyKind::Indexed(_, indices2)) => {
             // HACK(nilehmann) we should probably remove this once we have proper unpacking of &mut refs
             let sorts = genv.sorts(bty1);
-            let exprs1 = rcx.push_bindings(&sorts, p);
-            for (e1, idx2) in iter::zip(exprs1, indices2) {
+            let names1 = rcx.define_params(&sorts, p);
+            for (name1, idx2) in iter::zip(names1, indices2) {
                 if idx2.is_binder {
-                    infer_from_exprs(subst, params, &e1, &idx2.expr);
+                    infer_from_exprs(subst, params, &Expr::fvar(name1), &idx2.expr);
                 }
             }
         }

--- a/liquid-rust-typeck/src/type_env.rs
+++ b/liquid-rust-typeck/src/type_env.rs
@@ -114,7 +114,7 @@ impl TypeEnv {
                     *ty = new_ty;
                 }
                 LookupResult::Ref(RefKind::Mut, ty) => {
-                    let mut gen = ConstraintGen::new(genv, rcx.breadcrumb(), tag);
+                    let mut gen = ConstraintGen::new(genv, rcx, tag);
                     gen.subtyping(&new_ty, &ty);
                 }
                 LookupResult::Ref(RefKind::Shr, _) => {
@@ -256,7 +256,7 @@ impl TypeEnv {
         let subst = self.infer_subst_for_bb_env(bb_env);
 
         // Check constraints
-        let mut gen = ConstraintGen::new(genv, rcx.breadcrumb(), tag);
+        let mut gen = ConstraintGen::new(genv, rcx, tag);
         for (param, constr) in iter::zip(&bb_env.params, &bb_env.constrs) {
             gen.check_pred(subst.subst_pred(&constr.subst_bound_vars(&[Expr::fvar(param.name)])));
         }

--- a/liquid-rust-typeck/src/type_env.rs
+++ b/liquid-rust-typeck/src/type_env.rs
@@ -17,7 +17,7 @@ use liquid_rust_middle::{
 use crate::{
     constraint_gen::{ConstraintGen, Tag},
     param_infer,
-    pure_ctxt::{PureCtxt, Scope},
+    refine_tree::{RefineCtxt, Scope},
 };
 
 use self::paths_tree::{LookupResult, PathsTree};
@@ -67,9 +67,9 @@ impl TypeEnv {
     }
 
     #[track_caller]
-    pub fn lookup_place(&mut self, pcx: &mut PureCtxt, place: &Place) -> Ty {
+    pub fn lookup_place(&mut self, rcx: &mut RefineCtxt, place: &Place) -> Ty {
         self.bindings
-            .lookup_place(pcx, place, |_, result| result.ty())
+            .lookup_place(rcx, place, |_, result| result.ty())
     }
 
     #[track_caller]
@@ -83,8 +83,8 @@ impl TypeEnv {
 
     // TODO(nilehmann) find a better name for borrow in this context
     // TODO(nilehmann) unify borrow_mut and borrow_shr and return ptr(l)
-    pub fn borrow_mut(&mut self, pcx: &mut PureCtxt, place: &Place) -> Ty {
-        self.bindings.lookup_place(pcx, place, |_, result| {
+    pub fn borrow_mut(&mut self, rcx: &mut RefineCtxt, place: &Place) -> Ty {
+        self.bindings.lookup_place(rcx, place, |_, result| {
             match result {
                 LookupResult::Ptr(path, _) => Ty::strg_ref(path),
                 LookupResult::Ref(RefKind::Mut, ty) => Ty::mk_ref(RefKind::Mut, ty),
@@ -95,26 +95,26 @@ impl TypeEnv {
         })
     }
 
-    pub fn borrow_shr(&mut self, pcx: &mut PureCtxt, place: &Place) -> Ty {
+    pub fn borrow_shr(&mut self, rcx: &mut RefineCtxt, place: &Place) -> Ty {
         self.bindings
-            .lookup_place(pcx, place, |_, result| Ty::mk_ref(RefKind::Shr, result.ty()))
+            .lookup_place(rcx, place, |_, result| Ty::mk_ref(RefKind::Shr, result.ty()))
     }
 
     pub fn write_place(
         &mut self,
         genv: &GlobalEnv,
-        pcx: &mut PureCtxt,
+        rcx: &mut RefineCtxt,
         place: &Place,
         new_ty: Ty,
         tag: Tag,
     ) {
-        self.bindings.lookup_place(pcx, place, |pcx, result| {
+        self.bindings.lookup_place(rcx, place, |rcx, result| {
             match result {
                 LookupResult::Ptr(_, ty) => {
                     *ty = new_ty;
                 }
                 LookupResult::Ref(RefKind::Mut, ty) => {
-                    let mut gen = ConstraintGen::new(genv, pcx.breadcrumb(), tag);
+                    let mut gen = ConstraintGen::new(genv, rcx.breadcrumb(), tag);
                     gen.subtyping(&new_ty, &ty);
                 }
                 LookupResult::Ref(RefKind::Shr, _) => {
@@ -124,8 +124,8 @@ impl TypeEnv {
         });
     }
 
-    pub fn move_place(&mut self, pcx: &mut PureCtxt, place: &Place) -> Ty {
-        self.bindings.lookup_place(pcx, place, |_, result| {
+    pub fn move_place(&mut self, rcx: &mut RefineCtxt, place: &Place) -> Ty {
+        self.bindings.lookup_place(rcx, place, |_, result| {
             match result {
                 LookupResult::Ptr(_, ty) => {
                     let old = ty.clone();
@@ -148,10 +148,10 @@ impl TypeEnv {
         *ty = bound;
     }
 
-    pub fn unpack_ty(&mut self, genv: &GlobalEnv, pcx: &mut PureCtxt, ty: &Ty) -> Ty {
+    pub fn unpack_ty(&mut self, genv: &GlobalEnv, rcx: &mut RefineCtxt, ty: &Ty) -> Ty {
         match ty.kind() {
             TyKind::Exists(bty, p) => {
-                let indices = pcx
+                let indices = rcx
                     .push_bindings(&genv.sorts(bty), p)
                     .into_iter()
                     .map(Index::from)
@@ -159,17 +159,17 @@ impl TypeEnv {
                 Ty::indexed(bty.clone(), indices)
             }
             TyKind::Ref(RefKind::Shr, ty) => {
-                let ty = self.unpack_ty(genv, pcx, ty);
+                let ty = self.unpack_ty(genv, rcx, ty);
                 Ty::mk_ref(RefKind::Shr, ty)
             }
             _ => ty.clone(),
         }
     }
 
-    pub fn unpack(&mut self, genv: &GlobalEnv, pcx: &mut PureCtxt) {
+    pub fn unpack(&mut self, genv: &GlobalEnv, rcx: &mut RefineCtxt) {
         for path in self.bindings.paths().collect_vec() {
             let ty = self.bindings[&path].clone();
-            let ty = self.unpack_ty(genv, pcx, &ty);
+            let ty = self.unpack_ty(genv, rcx, &ty);
             self.bindings[&path] = ty;
         }
     }
@@ -246,17 +246,17 @@ impl TypeEnv {
     pub fn check_goto(
         mut self,
         genv: &GlobalEnv,
-        pcx: &mut PureCtxt,
+        rcx: &mut RefineCtxt,
         bb_env: &mut BasicBlockEnv,
         tag: Tag,
     ) {
-        self.bindings.fold_unfold_with(pcx, &bb_env.env.bindings);
+        self.bindings.fold_unfold_with(rcx, &bb_env.env.bindings);
 
         // Infer subst
         let subst = self.infer_subst_for_bb_env(bb_env);
 
         // Check constraints
-        let mut gen = ConstraintGen::new(genv, pcx.breadcrumb(), tag);
+        let mut gen = ConstraintGen::new(genv, rcx.breadcrumb(), tag);
         for (param, constr) in iter::zip(&bb_env.params, &bb_env.constrs) {
             gen.check_pred(subst.subst_pred(&constr.subst_bound_vars(&[Expr::fvar(param.name)])));
         }
@@ -303,12 +303,12 @@ impl TypeEnv {
 }
 
 impl TypeEnvInfer {
-    pub fn enter(&self, pcx: &mut PureCtxt) -> TypeEnv {
+    pub fn enter(&self, rcx: &mut RefineCtxt) -> TypeEnv {
         let mut subst = Subst::empty();
         // HACK(nilehmann) it is crucial that the order in this iteration is the same as
         // [`TypeEnvInfer::into_bb_env`] otherwise names will be out of order in the checking phase.
         for (name, sort) in self.params.iter() {
-            let e = pcx.push_binding(sort.clone(), &Pred::tt());
+            let e = rcx.push_binding(sort.clone(), &Pred::tt());
             subst.insert(*name, e);
         }
         self.env.clone().subst(&subst)
@@ -613,10 +613,10 @@ impl TypeEnvInfer {
 }
 
 impl BasicBlockEnv {
-    pub fn enter(&self, pcx: &mut PureCtxt) -> TypeEnv {
+    pub fn enter(&self, rcx: &mut RefineCtxt) -> TypeEnv {
         let mut subst = Subst::empty();
         for (param, constr) in self.params.iter().zip(&self.constrs) {
-            let e = pcx.push_binding(param.sort.clone(), &subst.subst_pred(constr));
+            let e = rcx.push_binding(param.sort.clone(), &subst.subst_pred(constr));
             subst.insert(param.name, e);
         }
         self.env.clone().subst(&subst)

--- a/tools/logreader.py
+++ b/tools/logreader.py
@@ -103,7 +103,7 @@ class Buff:
                 self.flush()
                 self.print()
                 self.print_bb_header(fields['bb'])
-                self.print_context(fields['pcx'], fields['env'])
+                self.print_context(fields['rcx'], fields['env'])
             elif fields['event'] == 'statement_start':
                 if fields['stmt'] == 'nop':
                     continue
@@ -111,15 +111,15 @@ class Buff:
             elif fields['event'] == 'statement_end':
                 if fields['stmt'] == 'nop':
                     continue
-                self.print_context(fields['pcx'], fields['env'])
+                self.print_context(fields['rcx'], fields['env'])
             elif fields['event'] == 'terminator_start':
                 self.print_terminator(fields['terminator'])
             elif fields['event'] == 'terminator_end':
-                self.print_context(fields['pcx'], fields['env'])
+                self.print_context(fields['rcx'], fields['env'])
                 self.print_rule()
             elif fields['event'] == 'check_goto':
                 self.print(f'goto {fields["target"]}')
-                self.print_context(fields['pcx'], fields['env'])
+                self.print_context(fields['rcx'], fields['env'])
                 self.print(fields['bb_env'])
                 self.print_rule()
             elif fields['event'] == 'infer_goto_enter':
@@ -144,8 +144,8 @@ class Buff:
     def print_terminator(self, terminator: str) -> None:
         self.print(colorize(ansi.MAGENTA, terminator))
 
-    def print_context(self, pcx: str, env: str) -> None:
-        self.print(pcx)
+    def print_context(self, rcx: str, env: str) -> None:
+        self.print(rcx)
         self.print(env)
 
 


### PR DESCRIPTION
* Use the name `Refine` (for refinement) instead of `Pure`.
* Rename `ConstraintBuilder` to `RefineTree` to reflect the tree-like structure of type-checking.
* Rename `PureCtxt` to `RefineCtxt`
* New interface `ConstrBuilder` similar to `RefineCtxt` (old `PureCtxt`) for building a `RefineTree`, with operations used specifically when checking constraints (e.g., at function calls).