### PR TITLE
filter out rustc cmd

### DIFF
--- a/liquid-rust/src/main.rs
+++ b/liquid-rust/src/main.rs
@@ -2,10 +2,16 @@ mod logger;
 use std::{env::args, io, process::exit};
 
 const CMD_PREFIX: &str = "-lr";
+const CMD_RUSTC: &str = "rustc";
 
 fn main() -> io::Result<()> {
     logger::install()?;
-    let args: Vec<String> = args().filter(|x| !x.starts_with(CMD_PREFIX)).collect();
+
+    // the extra != CMD_RUSTC is because the `rust-analyzer` plugin calls the `flux` binary
+    // with that extra argument that we want stripped out...
+    let args: Vec<String> = args()
+        .filter(|x| !x.starts_with(CMD_PREFIX) && x != CMD_RUSTC)
+        .collect();
 
     let exit_code = liquid_rust_driver::run_compiler(args);
     // Exit with the exit code returned by the compiler.


### PR DESCRIPTION
the little tweak to filter out the `rustc` in the cmdline invocation.